### PR TITLE
繰り返し項目の値に空欄が設定されてる場合、繰り返し番号順に項目が登録されない不具合を修正

### DIFF
--- a/xoops_trust_path/modules/xoonips/class/action/IndexDescriptionAction.class.php
+++ b/xoops_trust_path/modules/xoonips/class/action/IndexDescriptionAction.class.php
@@ -110,6 +110,7 @@ class Xoonips_IndexDescriptionAction extends Xoonips_ActionBase
 
         $indexBean = Xoonips_BeanFactory::getBean('IndexBean', $this->dirname, $this->trustDirname);
         $index = $indexBean->getIndex($index_id);
+        $oldTitle = $index['title'];
 
         $index_upload_dir = Functions::getXoonipsConfig($this->dirname, 'index_upload_dir');
         $upload_path = $index_upload_dir.'/index';
@@ -185,6 +186,13 @@ class Xoonips_IndexDescriptionAction extends Xoonips_ActionBase
 
                 return false;
             }
+        }
+
+        if ($oldTitle != $title) {
+            // write log
+            $this->log->recordUpdateIndexEvent($index_id);
+            // event
+            $this->notification->afterUserIndexRenamed($this->notification->beforeUserIndexRenamed($index_id));
         }
 
         if (empty($viewData['redirect_msg'])) {

--- a/xoops_trust_path/modules/xoonips/class/core/Item.class.php
+++ b/xoops_trust_path/modules/xoonips/class/core/Item.class.php
@@ -1596,8 +1596,8 @@ class Xoonips_Item
                                 if (!$itemExtendBean->insert($itemId, $tableName, $v, $loop, $groupid)) {
                                     return false;
                                 }
-                                ++$loop;
                             }
+                            ++$loop;
                         }
                     }
                 }

--- a/xoops_trust_path/modules/xoonips/lib/Xoonips/Handler/AbstractObjectHandler.php
+++ b/xoops_trust_path/modules/xoonips/lib/Xoonips/Handler/AbstractObjectHandler.php
@@ -352,7 +352,7 @@ abstract class AbstractObjectHandler extends AbstractHandler
                 $where[] = $keyField.'='.$varsArr[$keyField];
             }
             foreach ($varsArr as $field => $value) {
-                if (!in_array($field, $keyField)) {
+                if (!in_array($field, $keyFields)) {
                     $setArr[] = $field.'='.$value;
                 }
             }

--- a/xoops_trust_path/modules/xoonips/lib/Xoonips/Object/AbstractObject.php
+++ b/xoops_trust_path/modules/xoonips/lib/Xoonips/Object/AbstractObject.php
@@ -291,7 +291,7 @@ abstract class AbstractObject
             return null;
         }
 
-        return $this->mExtraVar[$key];
+        return $this->mExtraVars[$key];
     }
 
     /**


### PR DESCRIPTION
- Articleアイテムタイプにて、著者を３つ設定して２番目の項目を空欄にすると３番目の値が繰り上げて２番目に設定されるのを確認したため、修正をしてみました。
- インデックス説明編集にてインデックス名変更時に通知が動作しない問題を修正しました。
