### PR TITLE
Improving compatibility with version 3.4

### DIFF
--- a/xoops_trust_path/modules/xoonips/admin/actions/SystemBasicAction.class.php
+++ b/xoops_trust_path/modules/xoonips/admin/actions/SystemBasicAction.class.php
@@ -24,7 +24,7 @@ class Xoonips_Admin_SystemBasicAction extends Xoonips_Admin_AbstractConfigAction
      */
     protected function getConfigKeys()
     {
-        return array('moderator_gid', 'upload_dir');
+        return array('moderator_gid', 'upload_dir', 'url_compatible');
     }
 
     /**

--- a/xoops_trust_path/modules/xoonips/admin/class/installer/Installer.class.php
+++ b/xoops_trust_path/modules/xoonips/admin/class/installer/Installer.class.php
@@ -159,6 +159,9 @@ SQL;
             array('name' => 'access_key', 'value' => ''),
             array('name' => 'secret_access_key', 'value' => ''),
             array('name' => 'index_upload_dir', 'value' => XOOPS_ROOT_PATH.'/uploads'),
+            array('name' => 'url_compatible', 'value' => 'off'),
+            array('name' => 'ranking_last_update', 'value' => time()),
+            array('name' => 'ranking_lock_timeout', 'value' => '0'),
         );
         $this->_insertData('config', $configArr);
     }

--- a/xoops_trust_path/modules/xoonips/admin/forms/SystemBasicForm.class.php
+++ b/xoops_trust_path/modules/xoonips/admin/forms/SystemBasicForm.class.php
@@ -41,6 +41,14 @@ class Xoonips_Admin_SystemBasicForm extends Xoonips_AbstractActionForm
                     'required' => true,
                 ),
             ),
+            'url_compatible' => array(
+                'type' => self::TYPE_STRING,
+                'label' => constant($constpref.'_SYSTEM_BASIC_URL_COMPATIBLE_TITLE'),
+                'depends' => array(
+                    'required' => true,
+                        'mask' => '/^(?:on|off)$/',
+                    ),
+            ),
         );
     }
 
@@ -66,14 +74,14 @@ class Xoonips_Admin_SystemBasicForm extends Xoonips_AbstractActionForm
     {
         $constpref = '_AD_'.strtoupper($this->mDirname);
         $value = trim($this->get('upload_dir'));
-        $is_windows = (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN');
+        $is_windows = ('WIN' === strtoupper(substr(PHP_OS, 0, 3)));
         if (empty($value)) {
             return;
         }
         if ($is_windows) {
             $value = str_replace('\\', '/', $value);
         }
-        if ($value != '/' && substr($value, -1) == '/') {
+        if ('/' != $value && '/' == substr($value, -1)) {
             $value = substr($value, 0, -1);
         }
         if (!is_dir($value)) {
@@ -98,7 +106,7 @@ class Xoonips_Admin_SystemBasicForm extends Xoonips_AbstractActionForm
      */
     public static function is_writable($path)
     {
-        $is_windows = (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN');
+        $is_windows = ('WIN' === strtoupper(substr(PHP_OS, 0, 3)));
         if (!$is_windows) {
             return is_writable($path);
         } // it works if not IIS
@@ -106,7 +114,7 @@ class Xoonips_Admin_SystemBasicForm extends Xoonips_AbstractActionForm
         // NOTE: use a trailing slash for folders!!!
         // see http://bugs.php.net/bug.php?id=27609
         // see http://bugs.php.net/bug.php?id=30931
-        if (substr($path, -1) == '/') {
+        if ('/' == substr($path, -1)) {
             // recursively return a temporary file path
             return self::is_writable($path.uniqid(mt_rand()).'.tmp');
         } elseif (is_dir($path)) {
@@ -114,7 +122,7 @@ class Xoonips_Admin_SystemBasicForm extends Xoonips_AbstractActionForm
         }
         // check tmp file for read/write capabilities
         $rm = file_exists($path);
-        if (($f = @fopen($path, 'a')) === false) {
+        if (false === ($f = @fopen($path, 'a'))) {
             return false;
         }
         fclose($f);

--- a/xoops_trust_path/modules/xoonips/admin/templates/system_basic.html
+++ b/xoops_trust_path/modules/xoonips/admin/templates/system_basic.html
@@ -34,6 +34,19 @@
     </td>
   </tr>
   <tr>
+    <td class="head" style="width: 40%; vertical-align: top;">
+      <span style="font-weight: bold;"><{"`$constpref`_SYSTEM_BASIC_URL_COMPATIBLE_TITLE"|constant}></span>
+      <br /><br />
+      <span style="font-weight: normal;"><{"`$constpref`_SYSTEM_BASIC_URL_COMPATIBLE_DESC"|constant}></span>
+    </td>
+    <td class="even" style="width: 60%; vertical-align: top;">
+      <select name="url_compatible" size="1">
+        <option value="off"<{if $actionForm->get('url_compatible') == 'off'}> selected="selected"<{/if}>><{"`$constpref`_SYSTEM_BASIC_URL_COMPATIBLE_DEFAULT"|constant}></option>
+        <option value="on"<{if $actionForm->get('url_compatible') == 'on'}> selected="selected"<{/if}>><{"`$constpref`_SYSTEM_BASIC_URL_COMPATIBLE_VERSION3"|constant}></option>
+      </select>
+    </td>
+  </tr>
+  <tr>
     <td class="head" style="width: 40%; vertical-align: top;">&nbsp;</td>
     <td class="even" style="width: 60%; vertical-align: top;">
       <input type="submit" name="submit" value="<{"`$constpref`_LANG_UPDATE"|constant}>" />

--- a/xoops_trust_path/modules/xoonips/blocks/xoonips_tree.php
+++ b/xoops_trust_path/modules/xoonips/blocks/xoonips_tree.php
@@ -1,5 +1,7 @@
 <?php
 
+use Xoonips\Core\Functions;
+
 require_once dirname(__DIR__).'/class/core/Request.class.php';
 
 // xoonips index tree block
@@ -25,7 +27,7 @@ function b_xoonips_tree_show($options)
     $userBean = Xoonips_BeanFactory::getBean('UsersBean', $dirname);
     $itemUserBean = Xoonips_BeanFactory::getBean('ItemUsersLinkBean', $dirname, $trustDirname);
     $is_moderator = false;
-    if ($uid != XOONIPS_UID_GUEST) {
+    if (XOONIPS_UID_GUEST != $uid) {
         $is_moderator = $userBean->isModerator($uid);
     }
 
@@ -47,16 +49,16 @@ function b_xoonips_tree_show($options)
     $groupIndexes = array();
     $privateIndexes = array();
 
-    if ($uid == XOONIPS_UID_GUEST) {
+    if (XOONIPS_UID_GUEST == $uid) {
         $publicIndex = $indexBean->getPublicIndex();
         $publicGroupIndexes = $indexBean->getPublicGroupIndex();
     } else {
         // login users
         if (!empty($xoonipsEditIndex)) {
             // edit index - show editable indexes
-          if ($is_moderator) {
-              $publicIndex = $indexBean->getPublicIndex();
-          }
+            if ($is_moderator) {
+                $publicIndex = $indexBean->getPublicIndex();
+            }
             $groupIndexes = $indexBean->getGroupIndex2($puid);
             $privateIndexes = $indexBean->getPrivateIndex2($puid);
         } else {
@@ -69,7 +71,7 @@ function b_xoonips_tree_show($options)
     if (isset($xoonipsURL)) {
         $url = urlencode($xoonipsURL);
     } else {
-        $url = XOOPS_URL.'/modules/'.$dirname.'/list.php';
+        $url = XOOPS_URL.'/modules/'.$dirname.'/'.Functions::getItemListUrl($dirname);
     }
 
     if (empty($xoonipsTreeCheckBox)) {
@@ -89,12 +91,12 @@ function b_xoonips_tree_show($options)
     }
 
     // group index and public group index
-    if ($checkbox != true) {
+    if (true != $checkbox) {
         $groupIndexes = $indexBean->mergeIndexes($publicGroupIndexes, $groupIndexes);
     // if has checkbox
     } else {
         // if not moderator and not item user
-        if (!$is_moderator && $xoonipsItemId != null && !$itemUserBean->isLink($xoonipsItemId, $uid)) {
+        if (!$is_moderator && null != $xoonipsItemId && !$itemUserBean->isLink($xoonipsItemId, $uid)) {
             // only admin group index
             foreach ($groupIndexes as $key => $index) {
                 if (!$userBean->isGroupManager($index['groupid'], $uid)) {
@@ -132,11 +134,11 @@ function b_xoonips_tree_show($options)
         $indexes[$key]['title'] = $value['title'];
     }
     $block = array(
-        'isKHTML' => (strstr($_SERVER['HTTP_USER_AGENT'], 'KHTML') !== false),
         'checkbox' => $checkbox,
         'indexes' => $indexes,
         'trees' => $trees,
-        'dirname' => $dirname, );
+        'dirname' => $dirname,
+        'itemListUrl' => Functions::getItemListUrl($dirname), );
 
     return $block;
 }

--- a/xoops_trust_path/modules/xoonips/class/action/DetailAction.class.php
+++ b/xoops_trust_path/modules/xoonips/class/action/DetailAction.class.php
@@ -1,5 +1,7 @@
 <?php
 
+use Xoonips\Core\Functions;
+
 require_once dirname(__DIR__).'/core/Item.class.php';
 require_once dirname(__DIR__).'/core/ActionBase.class.php';
 require_once dirname(__DIR__).'/XmlItemExport.class.php';
@@ -98,7 +100,7 @@ class Xoonips_DetailAction extends Xoonips_ActionBase
         $breadcrumbs = array(
         array(
                 'name' => _MD_XOONIPS_ITEM_LISTING_ITEM,
-                'url' => 'list.php?index_id='.$indexId,
+                'url' => Functions::getItemListUrl($this->dirname).'?index_id='.$indexId,
         ),
         array(
                 'name' => _MD_XOONIPS_ITEM_DETAIL_ITEM_TITLE,
@@ -113,7 +115,7 @@ class Xoonips_DetailAction extends Xoonips_ActionBase
 
         $itembean = Xoonips_BeanFactory::getBean('ItemVirtualBean', $this->dirname, $this->trustDirname);
         $limit = $itembean->getDownloadLimit($itemId, $itemtypeId);
-        if ($limit === true && $uid == XOONIPS_UID_GUEST) {
+        if (true === $limit && XOONIPS_UID_GUEST == $uid) {
             $download_confirmation = $this->getDownloadConfirmation($itemId, $itemtypeId, true);
         } else {
             $download_confirmation = $this->getDownloadConfirmation($itemId, $itemtypeId, false);
@@ -147,7 +149,7 @@ class Xoonips_DetailAction extends Xoonips_ActionBase
         $message = '';
         if ($result) {
             foreach ($result as $link) {
-                if ($link['certify_state'] == XOONIPS_CERTIFY_REQUIRED || $link['certify_state'] == XOONIPS_WITHDRAW_REQUIRED) {
+                if (XOONIPS_CERTIFY_REQUIRED == $link['certify_state'] || XOONIPS_WITHDRAW_REQUIRED == $link['certify_state']) {
                     $message = sprintf(_MD_XOONIPS_WARNING_CANNOT_EDIT_LOCKED_ITEM,
                     _MD_XOONIPS_LOCK_TYPE_STRING_CERTIFY_OR_WITHDRAW_REQUEST);
                 }
@@ -182,7 +184,7 @@ class Xoonips_DetailAction extends Xoonips_ActionBase
         $result = $bean->getPublicIndexItemLinkInfo($itemId);
         if ($result) {
             foreach ($result as $link) {
-                if (($link['certify_state'] == XOONIPS_CERTIFY_REQUIRED || $link['certify_state'] == XOONIPS_WITHDRAW_REQUIRED) && $isModerator) {
+                if ((XOONIPS_CERTIFY_REQUIRED == $link['certify_state'] || XOONIPS_WITHDRAW_REQUIRED == $link['certify_state']) && $isModerator) {
                     return true;
                 }
             }
@@ -214,7 +216,7 @@ class Xoonips_DetailAction extends Xoonips_ActionBase
         $use_cc = '0';
         $rights = '';
         $item_rights = $bean->getRights($item_id, $itemtypeId);
-        if ($item_rights === false) {
+        if (false === $item_rights) {
         } else {
             $use_license = true;
             if (strlen($item_rights) >= 4) {
@@ -227,12 +229,12 @@ class Xoonips_DetailAction extends Xoonips_ActionBase
             }
         }
 
-        if ($attachment_dl_notify == '0' && !$use_license) {
+        if ('0' == $attachment_dl_notify && !$use_license) {
             return '';
         }
 
         $files = $this->getFileInfo($item_id);
-        if ($files == false || count($files) == 0) {
+        if (false == $files || 0 == count($files)) {
             return '';
         }
 
@@ -275,7 +277,7 @@ class Xoonips_DetailAction extends Xoonips_ActionBase
         $sql = 'select file_id, original_file_name, file_size, mime_type, timestamp from '
         .$xoopsDB->prefix($this->modulePrefix('item_file'))." where item_id = $item_id ";
         $result = $xoopsDB->query($sql);
-        if ($result == false) {
+        if (false == $result) {
             return false;
         }
         $files = array();

--- a/xoops_trust_path/modules/xoonips/class/action/EditAction.class.php
+++ b/xoops_trust_path/modules/xoonips/class/action/EditAction.class.php
@@ -57,7 +57,7 @@ class Xoonips_EditAction extends Xoonips_ActionBase
         $item = new Xoonips_Item($itemtypeId, $this->dirname, $this->trustDirname);
         $targetItemId = $request->getParameter('targetItemId');
         $item->setData($_POST, true);
-        if ($item->complete($targetItemId) === false) {
+        if (false === $item->complete($targetItemId)) {
             $viewData['relation'] = false;
         }
         $viewData['editryView'] = $item->getEditViewWithData();
@@ -181,7 +181,7 @@ class Xoonips_EditAction extends Xoonips_ActionBase
         $insertInfo = array();
         $item->setData($_POST, true);
         $item->editCheck($errors, $itemId);
-        if (count($errors->getErrors()) != 0) {
+        if (0 != count($errors->getErrors())) {
             $viewData['editryView'] = $item->getEditViewWithData();
             $viewData['errors'] = $errors->getView($this->dirname);
             $response->setViewData($viewData);
@@ -277,7 +277,7 @@ class Xoonips_EditAction extends Xoonips_ActionBase
         $breadcrumbs = array(
         array(
                 'name' => _MD_XOONIPS_ITEM_LISTING_ITEM,
-                'url' => 'list.php?index_id='.$index_id,
+                'url' => Functions::getItemListUrl($this->dirname).'?index_id='.$index_id,
         ),
         array(
                 'name' => _MD_XOONIPS_ITEM_DETAIL_ITEM_TITLE,
@@ -336,7 +336,7 @@ class Xoonips_EditAction extends Xoonips_ActionBase
         $breadcrumbs = array(
         array(
                 'name' => _MD_XOONIPS_ITEM_LISTING_ITEM,
-                'url' => 'list.php?index_id='.$indexId,
+                'url' => Functions::getItemListUrl($this->dirname).'?index_id='.$indexId,
         ),
         array(
                 'name' => _MD_XOONIPS_ITEM_DETAIL_ITEM_TITLE,
@@ -452,16 +452,16 @@ class Xoonips_EditAction extends Xoonips_ActionBase
                 $parameters[] = $user['uname'];
                 $errors->addError('_MD_XOONIPS_ITEM_WARNING_ITEM_NUMBER_LIMIT2', '', $parameters);
             } else {
-                $uids .= (strlen($uids) == 0) ? $uid : ','.$uid;
+                $uids .= (0 == strlen($uids)) ? $uid : ','.$uid;
             }
         }
         $viewData = array();
         $this->setCommonViewDataByEditOwners($itemId, $uids, $viewData);
-        if (count($errors->getErrors()) != 0) {
+        if (0 != count($errors->getErrors())) {
             $viewData['errors'] = $errors->getView($this->dirname);
         }
         $response->setViewData($viewData);
-        if (count($errors->getErrors()) != 0) {
+        if (0 != count($errors->getErrors())) {
             $response->setErrors($errors);
         }
         $response->setForward('searchOwners_success');
@@ -650,7 +650,7 @@ class Xoonips_EditAction extends Xoonips_ActionBase
         $breadcrumbs = array(
         array(
                 'name' => _MD_XOONIPS_ITEM_LISTING_ITEM,
-                'url' => 'list.php?index_id='.$indexId,
+                'url' => Functions::getItemListUrl($this->dirname).'?index_id='.$indexId,
         ),
         array(
                 'name' => _MD_XOONIPS_ITEM_DETAIL_ITEM_TITLE,
@@ -799,7 +799,7 @@ class Xoonips_EditAction extends Xoonips_ActionBase
         $viewData['storage_of_items_max'] = sprintf('%.02lf', $privateItemLimit['itemStorage'] / 1024 / 1024);
 
         $op = $request->getParameter('op');
-        if ($op == 'confirm' && $response->getForward() == 'confirm_success') {
+        if ('confirm' == $op && 'confirm_success' == $response->getForward()) {
             $xoonipsTreeCheckBox = false;
         } else {
             $xoonipsTreeCheckBox = true;
@@ -811,7 +811,7 @@ class Xoonips_EditAction extends Xoonips_ActionBase
         $publicIndex = $indexBean->getPublicIndex();
         $publicGroupIndexes = $indexBean->getPublicGroupIndex();
 
-        if ($uid != XOONIPS_UID_GUEST) {
+        if (XOONIPS_UID_GUEST != $uid) {
             $groupIndexes = $indexBean->getGroupIndex($uid);
             $privateIndex = $indexBean->getPrivateIndex($uid);
         }

--- a/xoops_trust_path/modules/xoonips/class/action/EditIndexAction.class.php
+++ b/xoops_trust_path/modules/xoonips/class/action/EditIndexAction.class.php
@@ -13,7 +13,7 @@ class Xoonips_EditIndexAction extends Xoonips_ActionBase
         $viewData = array();
         $indexId = $request->getParameter('index_id');
         $uid = $xoopsUser->getVar('uid');
-        if ($indexId == null) {
+        if (null == $indexId) {
             $index = $indexBean->getPrivateIndex($uid);
             $indexId = $index['index_id'];
         } else {
@@ -27,20 +27,20 @@ class Xoonips_EditIndexAction extends Xoonips_ActionBase
         }
 
         //if private index
-        if ($index['open_level'] == XOONIPS_OL_PRIVATE) {
+        if (XOONIPS_OL_PRIVATE == $index['open_level']) {
             $breadcrumbsName = _MD_XOONIPS_INDEX_PANKUZU_EDIT_PRIVATE_INDEX_KEYWORD;
             $limitLabel = _MD_XOONIPS_INDEX_NUMBER_OF_PRIVATE_INDEX_LABEL;
             $indexNumberLimit = Functions::getXoonipsConfig($this->dirname, 'private_index_number_limit');
             $indexCount = $indexBean->countUserIndexes($index['uid']);
-            //if group index
-        } elseif ($index['open_level'] == XOONIPS_OL_GROUP_ONLY) {
+        //if group index
+        } elseif (XOONIPS_OL_GROUP_ONLY == $index['open_level']) {
             $breadcrumbsName = _MD_XOONIPS_INDEX_PANKUZU_EDIT_GROUP_INDEX_KEYWORD;
             $limitLabel = _MD_XOONIPS_INDEX_NUMBER_OF_GROUP_INDEX_LABEL;
             $groupBean = Xoonips_BeanFactory::getBean('GroupsBean', $this->dirname);
             $group = $groupBean->getGroup($index['groupid']);
             $indexNumberLimit = $group['index_number_limit'];
             $indexCount = $indexBean->countGroupIndexes($index['groupid']);
-            // if public index
+        // if public index
         } else {
             $breadcrumbsName = _MD_XOONIPS_INDEX_PANKUZU_EDIT_PUBLIC_INDEX_KEYWORD;
         }
@@ -51,7 +51,7 @@ class Xoonips_EditIndexAction extends Xoonips_ActionBase
         );
         $viewData['xoops_breadcrumbs'] = $breadcrumbs;
         // if not public index
-        if ($index['open_level'] != XOONIPS_OL_PUBLIC) {
+        if (XOONIPS_OL_PUBLIC != $index['open_level']) {
             $viewData['limitLabel'] = $limitLabel;
             $viewData['indexNumberLimit'] = $indexNumberLimit;
             $viewData['indexCount'] = $indexCount;
@@ -76,6 +76,7 @@ class Xoonips_EditIndexAction extends Xoonips_ActionBase
         $viewData['token_ticket'] = $token_ticket;
         $viewData['dirname'] = $this->dirname;
         $viewData['mytrustdirname'] = $this->trustDirname;
+        $viewData['itemListUrl'] = Functions::getItemListUrl($this->dirname);
         $response->setViewData($viewData);
         $response->setForward('init_success');
 
@@ -126,7 +127,7 @@ class Xoonips_EditIndexAction extends Xoonips_ActionBase
         $uid = $xoopsUser->getVar('uid');
 
         // if update mode
-        if ($indexId != null) {
+        if (null != $indexId) {
             // check write right
             if (!$indexBean->checkWriteRight($indexId, $uid)) {
                 // User doesn't have the right to write.
@@ -135,7 +136,7 @@ class Xoonips_EditIndexAction extends Xoonips_ActionBase
                 return false;
             }
             $index = $indexBean->getIndex($indexId);
-            if ($index == false) {
+            if (false == $index) {
                 $response->setSystemError(_MD_XOONIPS_ERROR_DELETE_NOTEXIST_INDEX);
 
                 return false;
@@ -198,7 +199,7 @@ class Xoonips_EditIndexAction extends Xoonips_ActionBase
         }
 
         // if not input
-        if (trim($title) == '') {
+        if ('' == trim($title)) {
             $errors = new Xoonips_Errors();
             $parameters[] = _MD_XOONIPS_INDEX_TITLE;
             $errors->addError('_MD_XOONIPS_ERROR_REQUIRED', 'title', $parameters);
@@ -216,14 +217,14 @@ class Xoonips_EditIndexAction extends Xoonips_ActionBase
         }
 
         // if update mode
-        if ($indexId != null) {
+        if (null != $indexId) {
             $index = $indexBean->getIndex($indexId);
-            if ($index == false) {
+            if (false == $index) {
                 $response->setSystemError(_MD_XOONIPS_ERROR_DELETE_NOTEXIST_INDEX);
 
                 return false;
             }
-            if ($index['open_level'] != XOONIPS_OL_PRIVATE && $index['title'] != $title && $indexBean->isLocked($indexId)) {
+            if (XOONIPS_OL_PRIVATE != $index['open_level'] && $index['title'] != $title && $indexBean->isLocked($indexId)) {
                 $response->setSystemError(_MD_XOONIPS_ERROR_CANNOT_EDIT_LOCKED_INDEX);
 
                 return false;
@@ -244,10 +245,10 @@ class Xoonips_EditIndexAction extends Xoonips_ActionBase
                 $this->notification->afterUserIndexRenamed($notification_context);
             }
             $viewData['callbackvalue'] = _MD_XOONIPS_MSG_DBUPDATED;
-            // if registry mode
+        // if registry mode
         } else {
             $index = $indexBean->getIndex($parentIndexId);
-            if ($index == false) {
+            if (false == $index) {
                 $response->setSystemError(_MD_XOONIPS_ERROR_DELETE_NOTEXIST_INDEX);
 
                 return false;
@@ -308,12 +309,12 @@ class Xoonips_EditIndexAction extends Xoonips_ActionBase
         }
 
         // if private index
-        if ($index['open_level'] == XOONIPS_OL_PRIVATE) {
+        if (XOONIPS_OL_PRIVATE == $index['open_level']) {
             $rootIndex = $indexBean->getPrivateIndex($uid);
-            // if group index
-        } elseif ($index['open_level'] == XOONIPS_OL_GROUP_ONLY) {
+        // if group index
+        } elseif (XOONIPS_OL_GROUP_ONLY == $index['open_level']) {
             $rootIndex = $indexBean->getRootIndex($indexId);
-            // if public index
+        // if public index
         } else {
             $rootIndex = $indexBean->getPublicIndex();
         }
@@ -469,7 +470,7 @@ class Xoonips_EditIndexAction extends Xoonips_ActionBase
         $indexBean->deleteIndex($indexIds);
 
         // if private index
-        if ($index['open_level'] == XOONIPS_OL_PRIVATE) {
+        if (XOONIPS_OL_PRIVATE == $index['open_level']) {
             // get root index
             $privateIndex = $indexBean->getPrivateIndex($uid);
 
@@ -481,7 +482,7 @@ class Xoonips_EditIndexAction extends Xoonips_ActionBase
                 }
             }
             // if public index
-        } elseif ($index['open_level'] == XOONIPS_OL_PUBLIC) {
+        } elseif (XOONIPS_OL_PUBLIC == $index['open_level']) {
             foreach ($itemIds as $itemId) {
                 // if item is not linked in public ,public group
                 if (!$indexBean->isLinked2PublicItem($itemId)) {
@@ -537,14 +538,14 @@ class Xoonips_EditIndexAction extends Xoonips_ActionBase
         $uid = $xoopsUser->getVar('uid');
         $indexBean = Xoonips_BeanFactory::getBean('IndexBean', $this->dirname, $this->trustDirname);
         $rootIndex = $indexBean->getRootIndex($parentIndexId);
-        if ($rootIndex['open_level'] == XOONIPS_OL_PUBLIC) {
+        if (XOONIPS_OL_PUBLIC == $rootIndex['open_level']) {
             return true;
-            // if private index
-        } elseif ($rootIndex['open_level'] == XOONIPS_OL_PRIVATE) {
+        // if private index
+        } elseif (XOONIPS_OL_PRIVATE == $rootIndex['open_level']) {
             $indexNumberLimit = Functions::getXoonipsConfig($this->dirname, 'private_index_number_limit');
             $indexCount = $indexBean->countUserIndexes($rootIndex['uid']);
-            //if group index
-        } elseif ($rootIndex['open_level'] == XOONIPS_OL_GROUP_ONLY) {
+        //if group index
+        } elseif (XOONIPS_OL_GROUP_ONLY == $rootIndex['open_level']) {
             $groupBean = Xoonips_BeanFactory::getBean('GroupsBean', $this->dirname);
             $group = $groupBean->getGroup($rootIndex['groupid']);
             $indexNumberLimit = $group['index_number_limit'];
@@ -552,7 +553,7 @@ class Xoonips_EditIndexAction extends Xoonips_ActionBase
         }
 
         // if over index number limit
-        if ($indexNumberLimit != 0 && $indexCount >= $indexNumberLimit) {
+        if (0 != $indexNumberLimit && $indexCount >= $indexNumberLimit) {
             $response->setSystemError(_MD_XOONIPS_INDEX_TOO_MANY_INDEXES);
 
             return false;

--- a/xoops_trust_path/modules/xoonips/class/action/IndexDescriptionAction.class.php
+++ b/xoops_trust_path/modules/xoonips/class/action/IndexDescriptionAction.class.php
@@ -15,7 +15,7 @@ class Xoonips_IndexDescriptionAction extends Xoonips_ActionBase
         $viewData = array();
         $indexId = $request->getParameter('index_id');
         $uid = $xoopsUser->getVar('uid');
-        if ($indexId == null) {
+        if (null == $indexId) {
             $index = $indexBean->getPrivateIndex($uid);
             $indexId = $index['index_id'];
         } else {
@@ -38,7 +38,7 @@ class Xoonips_IndexDescriptionAction extends Xoonips_ActionBase
         $fullpathInfo = $indexBean->getFullPathIndexes($indexId);
         $fullPathIndexes = array();
         foreach ($fullpathInfo as $index) {
-            if ($index['parent_index_id'] == 1 && $index['open_level'] == XOONIPS_OL_PRIVATE) {
+            if (1 == $index['parent_index_id'] && XOONIPS_OL_PRIVATE == $index['open_level']) {
                 $index['html_title'] = 'Private';
             }
             $fullPathIndexes[] = $index;
@@ -56,7 +56,7 @@ class Xoonips_IndexDescriptionAction extends Xoonips_ActionBase
 
         // root dir check
         $root_dir = false;
-        if ($index['parent_index_id'] == XOONIPS_IID_ROOT) {
+        if (XOONIPS_IID_ROOT == $index['parent_index_id']) {
             $root_dir = true;
             if (!empty($index['uid'])) {
                 $index['title'] = self::PRIVATE_INDEX;
@@ -66,7 +66,7 @@ class Xoonips_IndexDescriptionAction extends Xoonips_ActionBase
         // back
         $back = $request->getParameter('back');
         if (empty($back)) {
-            $back = 'list.php?index_id='.$indexId;
+            $back = Functions::getItemListUrl($this->dirname).'?index_id='.$indexId;
         } else {
             $back = 'editindex.php?index_id='.$back;
         }
@@ -85,6 +85,7 @@ class Xoonips_IndexDescriptionAction extends Xoonips_ActionBase
         $token_ticket = $this->createToken($this->modulePrefix('index_description'));
         $viewData['token_ticket'] = $token_ticket;
         $viewData['dirname'] = $this->dirname;
+        $viewData['itemListUrl'] = Functions::getItemListUrl($this->dirname);
         $response->setViewData($viewData);
         $response->setViewDataByKey('index_path', $fullPathIndexes);
         $response->setForward('init_success');
@@ -120,7 +121,7 @@ class Xoonips_IndexDescriptionAction extends Xoonips_ActionBase
         if (!empty($file)) {
             $index['icon'] = $file['name'];
             $index['mime_type'] = $file['type'];
-        } elseif ($show_thumbnail == 2) {
+        } elseif (2 == $show_thumbnail) {
             $index['icon'] = null;
             $index['mime_type'] = null;
         }
@@ -128,7 +129,7 @@ class Xoonips_IndexDescriptionAction extends Xoonips_ActionBase
         // start transaction
         $this->startTransaction();
 
-        if ($index['parent_index_id'] != XOONIPS_IID_ROOT) {
+        if (XOONIPS_IID_ROOT != $index['parent_index_id']) {
             if (empty($title)) {
                 $viewData = array();
                 if (empty($viewData['redirect_msg'])) {
@@ -170,7 +171,7 @@ class Xoonips_IndexDescriptionAction extends Xoonips_ActionBase
             return true;
         }
 
-        if ($show_thumbnail == 2) {
+        if (2 == $show_thumbnail) {
             $uploadfile = $upload_path.'/'.$index_id;
             unlink($uploadfile);
         }
@@ -198,7 +199,7 @@ class Xoonips_IndexDescriptionAction extends Xoonips_ActionBase
         if (empty($viewData['redirect_msg'])) {
             $viewData['redirect_msg'] = _MD_XOONIPS_MESSAGE_INDEX_DESCRIPTION_UPDATE_SUCCESS;
         }
-        $viewData['url'] = 'list.php?index_id='.$index_id;
+        $viewData['url'] = Functions::getItemListUrl($this->dirname).'?index_id='.$index_id;
         $response->setViewData($viewData);
         $response->setForward('update_success');
 
@@ -243,7 +244,7 @@ class Xoonips_IndexDescriptionAction extends Xoonips_ActionBase
         if (empty($viewData['redirect_msg'])) {
             $viewData['redirect_msg'] = _MD_XOONIPS_MESSAGE_INDEX_DESCRIPTION_DELETE_SUCCESS;
         }
-        $viewData['url'] = 'list.php?index_id='.$index_id;
+        $viewData['url'] = Functions::getItemListUrl($this->dirname).'?index_id='.$index_id;
         $response->setViewData($viewData);
         $response->setForward('delete_success');
 

--- a/xoops_trust_path/modules/xoonips/class/action/ItemSelectSubAction.class.php
+++ b/xoops_trust_path/modules/xoonips/class/action/ItemSelectSubAction.class.php
@@ -33,7 +33,7 @@ class Xoonips_ItemSelectSubAction extends Xoonips_ActionBase
             $title = mb_convert_encoding($title, _CHARSET, 'utf-8');
         }
 
-        if ($indexId != '') {
+        if ('' != $indexId) {
             $itemIds = $indexBean->getCanViewItemIds($indexId, $uid);
         } else {
             $itemIds = $itemTitleBean->searchItemIdByTitle(trim($title));
@@ -48,10 +48,10 @@ class Xoonips_ItemSelectSubAction extends Xoonips_ActionBase
         if (!empty($sortIds)) {
             $defalut_orderby = $sortIds[0];
         }
-        $page = $request->getParameter('page') != '' ? $request->getParameter('page') : 1;
-        $orderby = $request->getParameter('orderby') != '' ? $request->getParameter('orderby') : $defalut_orderby;
-        $order_dir = $request->getParameter('order_dir') != '' ? $request->getParameter('order_dir') : XOONIPS_ASC;
-        $itemcount = $request->getParameter('itemcount') != '' ? $request->getParameter('itemcount') : 2;
+        $page = '' != $request->getParameter('page') ? $request->getParameter('page') : 1;
+        $orderby = '' != $request->getParameter('orderby') ? $request->getParameter('orderby') : $defalut_orderby;
+        $order_dir = '' != $request->getParameter('order_dir') ? $request->getParameter('order_dir') : XOONIPS_ASC;
+        $itemcount = '' != $request->getParameter('itemcount') ? $request->getParameter('itemcount') : 2;
 
         $cri = array('start' => ($page - 1) * $itemcount,
                 'rows' => $itemcount,
@@ -73,7 +73,7 @@ class Xoonips_ItemSelectSubAction extends Xoonips_ActionBase
         $num_of_items = count($itemIds);
         $item_no_label = false;
         $page_no_label = '';
-        if ($num_of_items == 0) {
+        if (0 == $num_of_items) {
             $item_no_label = '0 - 0 of 0 Items';
         } else {
             $_pMin = min(($page - 1) * $itemcount + 1, $num_of_items);
@@ -113,7 +113,7 @@ class Xoonips_ItemSelectSubAction extends Xoonips_ActionBase
         $privateIndex = false;
         $publicIndex = $indexBean->getPublicIndex();
         $publicGroupIndexes = $indexBean->getPublicGroupIndex();
-        if ($uid != XOONIPS_UID_GUEST) {
+        if (XOONIPS_UID_GUEST != $uid) {
             $groupIndexes = $indexBean->getGroupIndex($uid);
             $privateIndex = $indexBean->getPrivateIndex($uid);
         }

--- a/xoops_trust_path/modules/xoonips/class/action/ListAction.class.php
+++ b/xoops_trust_path/modules/xoonips/class/action/ListAction.class.php
@@ -41,7 +41,7 @@ class Xoonips_ListAction extends Xoonips_ActionBase
         foreach ($request_vars as $key => $meta) {
             list($type, $default) = $meta;
             $$key = $request->getParameter($key);
-            if ($$key == '') {
+            if ('' == $$key) {
                 $$key = $default;
             }
         }
@@ -78,7 +78,7 @@ class Xoonips_ListAction extends Xoonips_ActionBase
         $indexInfo = $indexBean->getIndex($index_id);
         if ($indexInfo) {
             $userBean = Xoonips_BeanFactory::getBean('UsersBean', $this->dirname);
-            if (!$userBean->isModerator($uid) && $indexInfo['open_level'] == XOONIPS_OL_PUBLIC) {
+            if (!$userBean->isModerator($uid) && XOONIPS_OL_PUBLIC == $indexInfo['open_level']) {
                 $export_enabled = false;
             }
 
@@ -137,19 +137,19 @@ class Xoonips_ListAction extends Xoonips_ActionBase
         $fullpathInfo = $indexBean->getFullPathIndexes($index_id);
         $fullPathIndexes = array();
         foreach ($fullpathInfo as $index) {
-            if ($index['parent_index_id'] == 1 && $index['open_level'] == XOONIPS_OL_PRIVATE) {
+            if (1 == $index['parent_index_id'] && XOONIPS_OL_PRIVATE == $index['open_level']) {
                 $index['html_title'] = 'Private';
             }
             $fullPathIndexes[] = $index;
         }
 
         // get page_no_label
-        if ($num_of_items == 0) {
+        if (0 == $num_of_items) {
             $page_no_label = _MD_XOONIPS_ITEM_NO_ITEM_LISTED;
         } else {
             $_pMin = min(($page - 1) * $itemcount + 1, $num_of_items);
             $_pMax = min($page * $itemcount, $num_of_items);
-            if ($_pMin == 1 && $_pMax == $num_of_items && $num_of_items == 1) {
+            if (1 == $_pMin && $_pMax == $num_of_items && 1 == $num_of_items) {
                 $page_no_label = '';
             } else {
                 $page_no_label = $_pMin.' - '.$_pMax.' of '.$num_of_items.' Items';
@@ -186,7 +186,7 @@ class Xoonips_ListAction extends Xoonips_ActionBase
         $response->setViewDataByKey('order_by_select', $sortTitles);
         $response->setViewDataByKey('item_count_select', array('20', '50', '100'));
         $response->setViewDataByKey('dirname', $this->dirname);
-        if ($isPrint == 'print') {
+        if ('print' == $isPrint) {
             $response->setViewDataByKey('isPrintPage', true);
         } else {
             $response->setViewDataByKey('isPrintPage', false);

--- a/xoops_trust_path/modules/xoonips/class/action/SearchAction.class.php
+++ b/xoops_trust_path/modules/xoonips/class/action/SearchAction.class.php
@@ -38,7 +38,7 @@ class Xoonips_SearchAction extends Xoonips_ActionBase
         $search_itemtype = $request->getParameter('search_itemtype');
         $search_subtype = $request->getParameter('search_subtype');
 
-        if (!is_null($search_subtype) && $search_subtype != '') {
+        if (!is_null($search_subtype) && '' != $search_subtype) {
             // do advanced search by subtype
             $this->doAdvancedSearchBySubType($request, $response);
             $response->setForward('advanced_search_success');
@@ -46,7 +46,7 @@ class Xoonips_SearchAction extends Xoonips_ActionBase
             return true;
         }
 
-        if (!is_null($search_itemtype) && $search_itemtype != '') {
+        if (!is_null($search_itemtype) && '' != $search_itemtype) {
             // do advanced search by itemtype
             $this->doAdvancedSearchByItemType($request, $response);
             $response->setForward('advanced_search_success');
@@ -150,7 +150,7 @@ class Xoonips_SearchAction extends Xoonips_ActionBase
     private function doAdvancedSearch(&$request, &$response)
     {
         $post_data = $_POST;
-        if (count($post_data) == 0) {
+        if (0 == count($post_data)) {
             $post_data = $_GET;
         }
         $iids = $this->_doAdvancedSearchBody($request, $post_data, $search_data);
@@ -217,7 +217,7 @@ class Xoonips_SearchAction extends Xoonips_ActionBase
         foreach ($request_vars as $key => $meta) {
             list($type, $default) = $meta;
             $$key = $request->getParameter($key);
-            if ($$key == '') {
+            if ('' == $$key) {
                 $$key = $default;
             }
         }
@@ -265,7 +265,7 @@ class Xoonips_SearchAction extends Xoonips_ActionBase
 
         $item_no_label = false;
         $page_no_label = '';
-        if ($num_of_items == 0) {
+        if (0 == $num_of_items) {
             $item_no_label = '0 - 0 of 0 Items';
         } else {
             $_pMin = min(($page - 1) * $itemcount + 1, $num_of_items);
@@ -282,7 +282,7 @@ class Xoonips_SearchAction extends Xoonips_ActionBase
         $response->setViewDataByKey('num_of_items', $num_of_items);
         $response->setViewDataByKey('page_no_label', $page_no_label);
 
-        ($print == 'print') ? $printPage = true : $printPage = false;
+        ('print' == $print) ? $printPage = true : $printPage = false;
         $response->setViewDataByKey('isPrintPage', $printPage);
 
         // assign export_enable variable if permitted
@@ -302,7 +302,7 @@ class Xoonips_SearchAction extends Xoonips_ActionBase
         foreach ($itemtypes as $itemtype) {
             $itemtypeId = $itemtype['item_type_id'];
             $checkValue = $request->getParameter($itemtypeId);
-            if ($checkValue == 'on') {
+            if ('on' == $checkValue) {
                 $checked[$itemtypeId] = true;
             } else {
                 $checked[$itemtypeId] = false;
@@ -332,10 +332,10 @@ class Xoonips_SearchAction extends Xoonips_ActionBase
         $keyword = $request->getParameter('keyword');
 
         $items = array();
-        if (!is_null($search_subtype) && $search_subtype != '') {
+        if (!is_null($search_subtype) && '' != $search_subtype) {
             // do advanced search by subtype
             $items = $this->doAdvancedSearchBySubTypeExport($request, $response);
-        } elseif (!is_null($search_itemtype) && $search_itemtype != '') {
+        } elseif (!is_null($search_itemtype) && '' != $search_itemtype) {
             // do advanced search by itemtype
             $items = $this->doAdvancedSearchByItemTypeExport($request, $response);
         } elseif (!is_null($search_parameter)) {
@@ -371,7 +371,7 @@ class Xoonips_SearchAction extends Xoonips_ActionBase
     private function doAdvancedSearchExport(&$request, &$response)
     {
         $post_data = $_POST;
-        if (count($post_data) == 0) {
+        if (0 == count($post_data)) {
             $post_data = $_GET;
         }
 
@@ -409,15 +409,15 @@ class Xoonips_SearchAction extends Xoonips_ActionBase
         $search_var = array();
         foreach ($post_data as $key => $value) {
             $idArray = explode(Xoonips_Enum::ITEM_ID_SEPARATOR, $key);
-            if (count($idArray) == 3) {
-                if ($checkedValue[$idArray[1]] === true) {
+            if (3 == count($idArray)) {
+                if (true === $checkedValue[$idArray[1]]) {
                     if (is_array($value)) {
-                        if (trim($value[0]) != ' ' || trim($value[1]) != '') {
+                        if (' ' != trim($value[0]) || '' != trim($value[1])) {
                             $search_data[$key] = $key.'='.$value[0].','.$value[1];
                             $search_var[$idArray[1]][$key] = $value;
                         }
                     } else {
-                        if (trim($value) != '') {
+                        if ('' != trim($value)) {
                             $search_data[$key] = $key.'='.trim($value);
                             $search_var[$idArray[1]][$key] = $value;
                         }
@@ -451,7 +451,7 @@ class Xoonips_SearchAction extends Xoonips_ActionBase
     private function _doQuickSearchBody($keyword, $search_condition)
     {
         $iids = array();
-        if (trim($keyword) != '') {
+        if ('' != trim($keyword)) {
             $chandler = Functions::getXoonipsHandler('ItemQuickSearchCondition', $this->dirname);
             $cobj = &$chandler->get($search_condition);
             if (is_object($cobj)) {
@@ -467,7 +467,7 @@ class Xoonips_SearchAction extends Xoonips_ActionBase
                 }
                 $searchSqlArr = array();
                 foreach ($post_data as $key => $data) {
-                    if ($itemtypeId == 0) {
+                    if (0 == $itemtypeId) {
                         $key = 0;
                     }
                     $item = new Xoonips_Item($key, $this->dirname, $this->trustDirname);

--- a/xoops_trust_path/modules/xoonips/class/ajax/GetIndexesInfo.class.php
+++ b/xoops_trust_path/modules/xoonips/class/ajax/GetIndexesInfo.class.php
@@ -135,14 +135,14 @@ class Xoonips_GetIndexesInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
      */
     private function maintenaceItemCommon($dirname, $trustDirname, $xoopsUser, $indexHandler, $public_flg, $checkedIndexes, $openedIndexes, $searchUserID = 0)
     {
-        if ($searchUserID != 0) {
+        if (0 != $searchUserID) {
             $uid = $searchUserID;
         } else {
             $uid = is_object($xoopsUser) ? $xoopsUser->getVar('uid') : XOONIPS_UID_GUEST;
         }
 
         $trees = array();
-        if ($public_flg == 1) {
+        if (1 == $public_flg) {
             // public index
             $trees[] = $this->_getPublicIndexTree($indexHandler, $uid, $checkedIndexes, $openedIndexes);
         } else {
@@ -190,13 +190,13 @@ class Xoonips_GetIndexesInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
         $functionName = $request->getParameter('function');
         $checkedIndexes = array();
         $openedIndexes = array();
-        if ($functionName == 'itemimport') {
+        if ('itemimport' == $functionName) {
             return self::itemImport($dirname, $trustDirname, $xoopsUser, $indexHandler);
-        } elseif ($functionName == 'register') {
+        } elseif ('register' == $functionName) {
             return self::register($dirname, $trustDirname, $xoopsUser, $indexHandler);
-        } elseif ($functionName == 'editItem') {
+        } elseif ('editItem' == $functionName) {
             return self::editItem($dirname, $trustDirname, $xoopsUser, $indexHandler, $xoonipsItemId);
-        } elseif ($functionName == 'commonItemDelete') {
+        } elseif ('commonItemDelete' == $functionName) {
             if (isset($_COOKIE['item_delete_checked_indexes'])) {
                 $checkedIndexes = explode(':', $_COOKIE['item_delete_checked_indexes']);
             }
@@ -205,7 +205,7 @@ class Xoonips_GetIndexesInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
             }
 
             return self::maintenaceItemCommon($dirname, $trustDirname, $xoopsUser, $indexHandler, 0, $checkedIndexes, $openedIndexes, $request->getParameter('searchUserID'));
-        } elseif ($functionName == 'commonItemTransferFrom') {
+        } elseif ('commonItemTransferFrom' == $functionName) {
             if (isset($_COOKIE['item_transfer_from_checked_indexes'])) {
                 $checkedIndexes = explode(':', $_COOKIE['item_transfer_from_checked_indexes']);
             }
@@ -214,7 +214,7 @@ class Xoonips_GetIndexesInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
             }
 
             return self::maintenaceItemCommon($dirname, $trustDirname, $xoopsUser, $indexHandler, 0, $checkedIndexes, $openedIndexes, $request->getParameter('searchUserID'));
-        } elseif ($functionName == 'commonItemTransferTo') {
+        } elseif ('commonItemTransferTo' == $functionName) {
             if (isset($_COOKIE['item_transfer_to_checked_indexes'])) {
                 $checkedIndexes = explode(':', $_COOKIE['item_transfer_to_checked_indexes']);
             }
@@ -223,7 +223,7 @@ class Xoonips_GetIndexesInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
             }
 
             return self::maintenaceItemCommon($dirname, $trustDirname, $xoopsUser, $indexHandler, 0, $checkedIndexes, $openedIndexes, $request->getParameter('searchUserID'));
-        } elseif ($functionName == 'commonItemWithDraw') {
+        } elseif ('commonItemWithDraw' == $functionName) {
             if (isset($_COOKIE['item_withdraw_checked_indexes'])) {
                 $checkedIndexes = explode(':', $_COOKIE['item_withdraw_checked_indexes']);
             }
@@ -288,7 +288,7 @@ class Xoonips_GetIndexesInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
         $public_index_id = '';
         $publicIndexes = $indexHandler->getPublicIndexList($uid);
         foreach ($publicIndexes as $index) {
-            if ($index['index_id'] == XOONIPS_IID_ROOT) {
+            if (XOONIPS_IID_ROOT == $index['index_id']) {
                 continue;
             }
             $html = array();
@@ -296,7 +296,7 @@ class Xoonips_GetIndexesInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
             $html['id'] = $index['index_id'];
             // parent
             $parent = $index['parent_index_id'];
-            if ($index['parent_index_id'] == XOONIPS_IID_ROOT) {
+            if (XOONIPS_IID_ROOT == $index['parent_index_id']) {
                 $parent = '#';
                 $public_index_id = $index['index_id'];
                 $html['state'] = array('opened' => true);
@@ -304,7 +304,7 @@ class Xoonips_GetIndexesInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
             $html['parent'] = $parent;
             // text
             $text = sprintf('%s(%s)', $index['title'], $index['num_items']);
-            if ($index['num_items'] == '0') {
+            if ('0' == $index['num_items']) {
                 $text = $index['title'];
             }
             $html['text'] = $text;
@@ -349,7 +349,7 @@ class Xoonips_GetIndexesInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
         $itemUserBean = Xoonips_BeanFactory::getBean('ItemUsersLinkBean', $dirname, $trustDirname);
         $indexBean = Xoonips_BeanFactory::getBean('IndexBean', $dirname, $trustDirname);
         $is_moderator = false;
-        if ($uid != XOONIPS_UID_GUEST) {
+        if (XOONIPS_UID_GUEST != $uid) {
             $is_moderator = $userBean->isModerator($uid);
         }
         $puid = array();
@@ -402,7 +402,7 @@ class Xoonips_GetIndexesInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
             $html['id'] = $index['index_id'];
             // parent
             $parent = $index['parent_index_id'];
-            if ($index['parent_index_id'] == XOONIPS_IID_ROOT) {
+            if (XOONIPS_IID_ROOT == $index['parent_index_id']) {
                 $parent = '#';
                 $group_index_id = $index['index_id'];
                 $html['state'] = array('opened' => true);
@@ -410,7 +410,7 @@ class Xoonips_GetIndexesInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
             $html['parent'] = $parent;
             // text
             $text = sprintf('%s(%s)', $index['title'], $index['num_items']);
-            if ($index['num_items'] == '0') {
+            if ('0' == $index['num_items']) {
                 $text = $index['title'];
             }
             $html['text'] = $text;
@@ -465,7 +465,7 @@ class Xoonips_GetIndexesInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
             $html['id'] = $index['index_id'];
             // parent
             $parent = $index['parent_index_id'];
-            if ($index['parent_index_id'] == XOONIPS_IID_ROOT) {
+            if (XOONIPS_IID_ROOT == $index['parent_index_id']) {
                 $parent = '#';
                 $private_index_id = $index['index_id'];
                 $index['title'] = 'Private';
@@ -474,7 +474,7 @@ class Xoonips_GetIndexesInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
             $html['parent'] = $parent;
             // text
             $text = sprintf('%s(%s)', $index['title'], $index['num_items']);
-            if ($index['num_items'] == '0') {
+            if ('0' == $index['num_items']) {
                 $text = $index['title'];
             }
             $html['text'] = $text;

--- a/xoops_trust_path/modules/xoonips/class/ajax/GetViewTypeInfo.class.php
+++ b/xoops_trust_path/modules/xoonips/class/ajax/GetViewTypeInfo.class.php
@@ -14,7 +14,7 @@ class Xoonips_GetViewTypeInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
      */
     public function execute()
     {
-        if (($uid = XoopsUtils::getUid()) == XOONIPS_UID_GUEST) {
+        if (XOONIPS_UID_GUEST == ($uid = XoopsUtils::getUid())) {
             return false;
         }
         if (!XoopsUtils::isAdmin($uid, $this->mDirname)) {
@@ -30,7 +30,7 @@ class Xoonips_GetViewTypeInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
         if (!in_array($mode, array('', 'default'))) {
             return false;
         }
-        if ($mode == '') {
+        if ('' == $mode) {
             $ret = array(
                 'hasSelectionList' => $vtObj->hasSelectionList(),
                 'dataTypesInfo' => $vtObj->getDataTypesInfo(),
@@ -38,7 +38,7 @@ class Xoonips_GetViewTypeInfoAjaxMethod extends Xoonips_AbstractAjaxMethod
         } else {
             $list = trim($this->mRequest->getRequest('list'));
             $default = trim($this->mRequest->getRequest('default'));
-            $disabled = (intval($this->mRequest->getRequest('disabled')) == 0 ? false : true);
+            $disabled = (0 == intval($this->mRequest->getRequest('disabled')) ? false : true);
             $ret = $vtObj->getDefaultValueAdminHtml($list, $default, $disabled);
         }
         $this->mResult = json_encode($ret);

--- a/xoops_trust_path/modules/xoonips/class/ajax/LinkCountUp.class.php
+++ b/xoops_trust_path/modules/xoonips/class/ajax/LinkCountUp.class.php
@@ -22,24 +22,24 @@ class Xoonips_LinkCountUpAjaxMethod extends Xoonips_AbstractAjaxMethod
         $type = trim($this->mRequest->getRequest('type'));
         $field = trim($this->mRequest->getRequest('field'));
         $ids = explode(':', $field);
-        if ($itemId == 0) {
+        if (0 == $itemId) {
             return $this->_returnWithValue(false);
         }
         if (!in_array($type, array('xml', 'id'))) {
             return $this->_returnWithValue(false);
         }
-        if (count($ids) != 2) {
+        if (2 != count($ids)) {
             return $this->_returnWithValue(false);
         }
         // get item type id
         $itemBean = Xoonips_BeanFactory::getBean('ItemVirtualBean', $this->mDirname, $this->mTrustDirname);
         $item = $itemBean->getItem2($itemId);
-        if ($item['xoonips_item'] === false) {
+        if (false === $item['xoonips_item']) {
             return $this->_returnWithValue(false);
         }
         $itemTypeId = $item['xoonips_item']['item_type_id'];
         // get group id and field id
-        if ($type == 'id') {
+        if ('id' == $type) {
             list($groupId, $fieldId) = array_map('intval', $ids);
         } else {
             list($gXml, $fXml) = array_map('trim', $ids);
@@ -48,7 +48,7 @@ class Xoonips_LinkCountUpAjaxMethod extends Xoonips_AbstractAjaxMethod
             }
             list($groupId, $fieldId) = $this->_getFieldInfoByXml($gXml, $fXml);
         }
-        if ($groupId == 0 || $fieldId == 0) {
+        if (0 == $groupId || 0 == $fieldId) {
             return $this->_returnWithValue(false);
         }
         // get complement target
@@ -60,7 +60,7 @@ class Xoonips_LinkCountUpAjaxMethod extends Xoonips_AbstractAjaxMethod
                 $target[] = $link;
             }
         }
-        if (count($target) != 1) {
+        if (1 != count($target)) {
             return $this->_returnWithValue(false);
         }
         $target = array_shift($target);
@@ -73,7 +73,7 @@ class Xoonips_LinkCountUpAjaxMethod extends Xoonips_AbstractAjaxMethod
         // get current data
         $extendBean = Xoonips_BeanFactory::getBean('ItemExtendBean', $this->mDirname, $this->mTrustDirname);
         $info = $extendBean->getItemExtendInfo($itemId, $tableName, $targetGroupId);
-        if (count($info) != 1) {
+        if (1 != count($info)) {
             return $this->_returnWithValue(false);
         }
         $info = array_shift($info);

--- a/xoops_trust_path/modules/xoonips/class/bean/ItemVirtualBean.class.php
+++ b/xoops_trust_path/modules/xoonips/class/bean/ItemVirtualBean.class.php
@@ -65,25 +65,25 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
                     $itemUsersBean = Xoonips_BeanFactory::getBean('ItemUsersLinkBean', $this->dirname, $this->trustDirname);
                     $info = $itemUsersBean->getItemUsersInfo($itemId);
                 }
-            // if item relation table
+                // if item relation table
             } elseif ($tableName == $this->modulePrefix('item_related_to')) {
                 if (!$itemRelationBean) {
                     $itemRelationBean = Xoonips_BeanFactory::getBean('ItemRelatedToBean', $this->dirname, $this->trustDirname);
                     $info = $itemRelationBean->getRelatedToInfo($itemId);
                 }
-            // if item title table
+                // if item title table
             } elseif ($tableName == $this->modulePrefix('item_title')) {
                 if (!$itemTitleBean) {
                     $itemTitleBean = Xoonips_BeanFactory::getBean('ItemTitleBean', $this->dirname, $this->trustDirname);
                     $info = $itemTitleBean->getItemTitleInfo($itemId);
                 }
-            // if item keyword table
+                // if item keyword table
             } elseif ($tableName == $this->modulePrefix('item_keyword')) {
                 if (!$itemKeywordBean) {
                     $itemKeywordBean = Xoonips_BeanFactory::getBean('ItemKeywordBean', $this->dirname, $this->trustDirname);
                     $info = $itemKeywordBean->getKeywords($itemId);
                 }
-            // if file table
+                // if file table
             } elseif ($tableName == $this->modulePrefix('item_file')) {
                 if (!$fileBean) {
                     $fileBean = Xoonips_BeanFactory::getBean('ItemFileBean', $this->dirname, $this->trustDirname);
@@ -97,14 +97,14 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
                     $indexItemLinkBean = Xoonips_BeanFactory::getBean('IndexItemLinkBean', $this->dirname, $this->trustDirname);
                     $info = $indexItemLinkBean->getIndexItemLinkInfo($itemId);
                 }
-            // if change log table
+                // if change log table
             } elseif ($tableName == $this->modulePrefix('item_changelog')) {
                 if (!$changeLogBean) {
                     $changeLogBean = Xoonips_BeanFactory::getBean('ItemChangeLogBean', $this->dirname, $this->trustDirname);
                     $info = $changeLogBean->getChangeLogs($itemId);
                 }
-            // if item extend
-            } elseif (strncmp($tableName, $this->modulePrefix('item_extend'), strlen($this->dirname) + 12) == 0) {
+                // if item extend
+            } elseif (0 == strncmp($tableName, $this->modulePrefix('item_extend'), strlen($this->dirname) + 12)) {
                 if (!$itemExtendBean) {
                     $itemExtendBean = Xoonips_BeanFactory::getBean('ItemExtendBean', $this->dirname, $this->trustDirname);
                 }
@@ -190,11 +190,11 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
         if ($linkInfos) {
             foreach ($linkInfos as $linkInfo) {
                 $index = $indexBean->getIndex($linkInfo['index_id']);
-                if ($index['open_level'] == XOONIPS_OL_PUBLIC) {
+                if (XOONIPS_OL_PUBLIC == $index['open_level']) {
                     if (in_array($linkInfo['certify_state'], array(XOONIPS_CERTIFIED, XOONIPS_WITHDRAW_REQUIRED))) {
                         return true;
                     }
-                } elseif ($index['open_level'] == XOONIPS_OL_GROUP_ONLY) {
+                } elseif (XOONIPS_OL_GROUP_ONLY == $index['open_level']) {
                     if ($userBean->isGroupManager($index['groupid'], $uid)) {
                         return true;
                     }
@@ -243,13 +243,13 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
     public function getItemsList($item_ids, $criteria)
     {
         $items = array();
-        if (count($item_ids) == 0) {
+        if (0 == count($item_ids)) {
             return $items;
         }
         $itemTable = $this->prefix($this->modulePrefix('item'));
         $itemBean = Xoonips_BeanFactory::getBean('ItemBean', $this->dirname, $this->trustDirname);
         $sql = '';
-        if ($criteria['orderby'] == '0') {
+        if ('0' == $criteria['orderby']) {
             $sql = "SELECT DISTINCT item_id FROM $itemTable WHERE item_id IN ( ".$this->getCsvStr($item_ids).' )';
             $criteria['order'] = ' item_id ';
         } else {
@@ -325,9 +325,9 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
         $sql = '';
         if (isset($cri['order']) && isset($cri['orderdir'])) {
             $orders = ' (CASE WHEN '.$cri['order']."='' THEN 1 WHEN ".$cri['order'].' IS NULL THEN 2 ELSE 0 END ) ';
-            if ($cri['orderdir'] == 0) {
+            if (0 == $cri['orderdir']) {
                 $orders .= ' , '.$cri['order'].' ASC';
-            } elseif ($cri['orderdir'] == 1) {
+            } elseif (1 == $cri['orderdir']) {
                 $orders .= ' , '.$cri['order'].' DESC';
             }
             $sql .= " ORDER BY $orders ";
@@ -387,7 +387,7 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
             return false;
         }
         if ($row = $this->fetchArray($result)) {
-            if ($row['count'] != 0) {
+            if (0 != $row['count']) {
                 $ret = true;
             }
         }
@@ -413,7 +413,7 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
             return false;
         }
         while ($row = $this->fetchArray($result)) {
-            if (strpos($row['table_name'], 'item_extend') !== false) {
+            if (false !== strpos($row['table_name'], 'item_extend')) {
                 $ret[] = $row['table_name'];
             }
         }
@@ -463,7 +463,7 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
             return 0;
         }
         if ($row = $this->fetchArray($result)) {
-            if ($row['count'] != 0) {
+            if (0 != $row['count']) {
                 $ret = $row['count'];
             }
         }
@@ -491,7 +491,7 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
             return false;
         }
         while ($row = $this->fetchArray($result)) {
-            if (strpos($row['table_name'], 'item_extend') !== false) {
+            if (false !== strpos($row['table_name'], 'item_extend')) {
                 $extendTable = $this->prefix($row['table_name']);
                 $extendSql = "SELECT DISTINCT value FROM $extendTable WHERE item_id=$itemId";
                 $extendRet = $this->execute($extendSql);
@@ -528,7 +528,7 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
             return false;
         }
         while ($row = $this->fetchArray($result)) {
-            if (strpos($row['table_name'], 'item_extend') !== false) {
+            if (false !== strpos($row['table_name'], 'item_extend')) {
                 $extendTable = $this->prefix($row['table_name']);
                 $extendSql = "SELECT DISTINCT value FROM $extendTable WHERE item_id=$itemId";
                 $entendRet = $this->execute($extendSql);
@@ -565,7 +565,7 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
             return false;
         }
         while ($row = $this->fetchArray($result)) {
-            if (strpos($row['table_name'], 'item_extend') !== false) {
+            if (false !== strpos($row['table_name'], 'item_extend')) {
                 $extendTable = $this->prefix($row['table_name']);
                 $extendSql = "SELECT DISTINCT value FROM $extendTable WHERE item_id=$itemId";
                 $entendRet = $this->execute($extendSql);
@@ -573,7 +573,7 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
                     return false;
                 }
                 while ($entendRow = $this->fetchArray($entendRet)) {
-                    return $entendRow['value'] == 0;
+                    return 0 == $entendRow['value'];
                 }
                 $this->freeRecordSet($entendRet);
             }
@@ -725,12 +725,12 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
         $columnName = '';
         foreach ($itemFields as $itemField) {
             $viewtype = $itemField->getViewType();
-            if ($viewtype != null && $viewtype->getName() == 'file type') {
+            if (null != $viewtype && 'file type' == $viewtype->getName()) {
                 $tableName = $itemField->getTableName();
                 $columnName = $itemField->getColumnName();
             }
         }
-        if ($tableName == '' || $columnName == '') {
+        if ('' == $tableName || '' == $columnName) {
             return $items;
         }
 
@@ -775,12 +775,12 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
                 $indexId = $index['index_id'];
                 $level = $index['open_level'];
                 $title = $index['title'];
-                if ($level == XOONIPS_OL_PUBLIC) {
+                if (XOONIPS_OL_PUBLIC == $level) {
                     $ret[0][$indexId] = sprintf(_MD_XOONIPS_ITEM_PUBLIC_REQUEST_MESSAGE, $title);
-                } elseif ($level == XOONIPS_OL_GROUP_ONLY) {
+                } elseif (XOONIPS_OL_GROUP_ONLY == $level) {
                     $ret[0][$indexId] = sprintf(_MD_XOONIPS_ITEM_GROUP_REQUEST_MESSAGE, $title);
-                } elseif ($level == XOONIPS_OL_PRIVATE) {
-                    if ($index['uid'] == $xoopsUid && $index['parent_index_id'] == 1) {
+                } elseif (XOONIPS_OL_PRIVATE == $level) {
+                    if ($index['uid'] == $xoopsUid && 1 == $index['parent_index_id']) {
                         $title = 'Private';
                     }
                     $ret[0][$indexId] = sprintf(_MD_XOONIPS_ITEM_PRIVATE_REGIST_MESSAGE, $title);
@@ -795,35 +795,35 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
             $state = $index['certify_state'];
             // delete index
             if (!isset($checkIndexes[$key])) {
-                if ($level == XOONIPS_OL_PUBLIC) {
-                    if ($state == XOONIPS_CERTIFIED) {
+                if (XOONIPS_OL_PUBLIC == $level) {
+                    if (XOONIPS_CERTIFIED == $state) {
                         $ret[1][$indexId] = sprintf(_MD_XOONIPS_ITEM_PUBLIC_CANCEL_REQUEST_MESSAGE, $title);
-                    } elseif ($state == XOONIPS_CERTIFY_REQUIRED) {
+                    } elseif (XOONIPS_CERTIFY_REQUIRED == $state) {
                         $ret[2][$indexId] = sprintf(_MD_XOONIPS_ITEM_PUBLIC_REQUEST_STOP_MESSAGE, $title);
                     }
-                } elseif ($level == XOONIPS_OL_GROUP_ONLY) {
-                    if ($state == XOONIPS_CERTIFIED) {
+                } elseif (XOONIPS_OL_GROUP_ONLY == $level) {
+                    if (XOONIPS_CERTIFIED == $state) {
                         $ret[1][$indexId] = sprintf(_MD_XOONIPS_ITEM_GROUP_CANCEL_REQUEST_MESSAGE, $title);
-                    } elseif ($state == XOONIPS_CERTIFY_REQUIRED) {
+                    } elseif (XOONIPS_CERTIFY_REQUIRED == $state) {
                         $ret[2][$indexId] = sprintf(_MD_XOONIPS_ITEM_GROUP_REQUEST_STOP_MESSAGE, $title);
                     }
-                } elseif ($level == XOONIPS_OL_PRIVATE && $state == XOONIPS_NOT_CERTIFIED) {
-                    if ($index['uid'] == $xoopsUid && $index['parent_index_id'] == 1) {
+                } elseif (XOONIPS_OL_PRIVATE == $level && XOONIPS_NOT_CERTIFIED == $state) {
+                    if ($index['uid'] == $xoopsUid && 1 == $index['parent_index_id']) {
                         $title = 'Private';
                     }
                     $ret[1][$indexId] = sprintf(_MD_XOONIPS_ITEM_PRIVATE_DELETE_MESSAGE, $title);
                 }
             } else {
-                if ($level == XOONIPS_OL_PUBLIC) {
-                    if ($state == XOONIPS_WITHDRAW_REQUIRED) {
+                if (XOONIPS_OL_PUBLIC == $level) {
+                    if (XOONIPS_WITHDRAW_REQUIRED == $state) {
                         $ret[2][$indexId] = sprintf(_MD_XOONIPS_ITEM_PUBLIC_CANCEL_REQUEST_STOP_MESSAGE, $title);
-                    } elseif ($state == XOONIPS_CERTIFIED) {
+                    } elseif (XOONIPS_CERTIFIED == $state) {
                         $ret[3][$indexId] = sprintf(_MD_XOONIPS_ITEM_PUBLIC_REQUEST_MESSAGE, $title);
                     }
-                } elseif ($level == XOONIPS_OL_GROUP_ONLY) {
-                    if ($state == XOONIPS_WITHDRAW_REQUIRED) {
+                } elseif (XOONIPS_OL_GROUP_ONLY == $level) {
+                    if (XOONIPS_WITHDRAW_REQUIRED == $state) {
                         $ret[2][$indexId] = sprintf(_MD_XOONIPS_ITEM_GROUP_CANCEL_REQUEST_STOP_MESSAGE, $title);
-                    } elseif ($state == XOONIPS_CERTIFIED) {
+                    } elseif (XOONIPS_CERTIFIED == $state) {
                         $ret[3][$indexId] = sprintf(_MD_XOONIPS_ITEM_GROUP_REQUEST_MESSAGE, $title);
                     }
                 }
@@ -881,18 +881,18 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
         $groupsLinkBean = Xoonips_BeanFactory::getBean('GroupsUsersLinkBean', $this->dirname, $this->trustDirname);
 
         $certify = Functions::getXoonipsConfig($this->dirname, 'certify_item');
-        if ($certify_item != null) {
+        if (null != $certify_item) {
             $certify = $certify_item;
         }
 
         foreach ($typeInfo as $type) {
             $indexId = $type['indexId'];
-            if ($type['type'] == 'add') {
+            if ('add' == $type['type']) {
                 // add index
-                if ($type['open_level'] == XOONIPS_OL_PUBLIC) {
+                if (XOONIPS_OL_PUBLIC == $type['open_level']) {
                     $dataname = Xoonips_Enum::WORKFLOW_PUBLIC_ITEMS;
                     $moderatorUids = $groupsLinkBean->getModeratorUserIds();
-                    if ($certify == 'auto') {
+                    if ('auto' == $certify) {
                         if (!$linkBean->insert($indexId, $itemId, XOONIPS_CERTIFIED)) {
                             return false;
                         }
@@ -929,12 +929,12 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
                             $eventLogBean->recordCertifyItemEvent($itemId, $indexId);
                         }
                     }
-                } elseif ($type['open_level'] == XOONIPS_OL_GROUP_ONLY) {
+                } elseif (XOONIPS_OL_GROUP_ONLY == $type['open_level']) {
                     $groupId = $type['groupid'];
                     $accept = $type['item_accept'];
                     $dataname = Xoonips_Enum::WORKFLOW_GROUP_ITEMS;
                     $groupAdminUids = $groupsLinkBean->getAdminUserIds($groupId);
-                    if ($accept == '1') {
+                    if ('1' == $accept) {
                         if (!$linkBean->insert($indexId, $itemId, XOONIPS_CERTIFIED)) {
                             return false;
                         }
@@ -972,19 +972,19 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
                             $eventLogBean->recordCertifyGroupItemEvent($indexId, $itemId);
                         }
                     }
-                } elseif ($type['open_level'] == XOONIPS_OL_PRIVATE) {
+                } elseif (XOONIPS_OL_PRIVATE == $type['open_level']) {
                     if (!$linkBean->insert($indexId, $itemId, XOONIPS_NOT_CERTIFIED)) {
                         return false;
                     }
                 }
-            } elseif ($type['type'] == 'delete') {
+            } elseif ('delete' == $type['type']) {
                 // delete index
                 $indexItemLinkInfo = $linkBean->getInfo($itemId, $indexId);
                 $indexItemLinkId = $indexItemLinkInfo['index_item_link_id'];
-                if ($type['open_level'] == XOONIPS_OL_PUBLIC) {
+                if (XOONIPS_OL_PUBLIC == $type['open_level']) {
                     $dataname = Xoonips_Enum::WORKFLOW_PUBLIC_ITEMS_WITHDRAWAL;
                     $moderatorUids = $groupsLinkBean->getModeratorUserIds();
-                    if ($certify == 'auto') {
+                    if ('auto' == $certify) {
                         if (!$linkBean->deleteById($indexId, $itemId)) {
                             return false;
                         }
@@ -1017,12 +1017,12 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
                             $eventLogBean->recordCertifyItemWithdrawalEvent($itemId, $indexId);
                         }
                     }
-                } elseif ($type['open_level'] == XOONIPS_OL_GROUP_ONLY) {
+                } elseif (XOONIPS_OL_GROUP_ONLY == $type['open_level']) {
                     $groupId = $type['groupid'];
                     $accept = $type['item_accept'];
                     $dataname = Xoonips_Enum::WORKFLOW_GROUP_ITEMS_WITHDRAWAL;
                     $groupAdminUids = $groupsLinkBean->getAdminUserIds($groupId);
-                    if ($accept == '1') {
+                    if ('1' == $accept) {
                         if (!$linkBean->deleteById($indexId, $itemId)) {
                             return false;
                         }
@@ -1056,19 +1056,19 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
                             $eventLogBean->recordCertifyGroupItemWithdrawalEvent($itemId, $indexId);
                         }
                     }
-                } elseif ($type['open_level'] == XOONIPS_OL_PRIVATE) {
+                } elseif (XOONIPS_OL_PRIVATE == $type['open_level']) {
                     if (!$linkBean->deleteById($indexId, $itemId)) {
                         return false;
                     }
                 }
-            } elseif ($type['type'] == 'update') {
+            } elseif ('update' == $type['type']) {
                 //update public index
                 $indexItemLinkInfo = $linkBean->getInfo($itemId, $indexId);
                 $indexItemLinkId = $indexItemLinkInfo['index_item_link_id'];
-                if ($type['open_level'] == XOONIPS_OL_PUBLIC) {
+                if (XOONIPS_OL_PUBLIC == $type['open_level']) {
                     $dataname = Xoonips_Enum::WORKFLOW_PUBLIC_ITEMS;
                     $moderatorUids = $groupsLinkBean->getModeratorUserIds();
-                    if ($certify == 'auto') {
+                    if ('auto' == $certify) {
                         $sendToUsers = Xoonips_Workflow::getAllApproverUserIds($this->dirname, $dataname, $indexItemLinkId);
                         $sendToUsers = array_merge($sendToUsers, $moderatorUids);
                         $sendToUsers = array_unique($sendToUsers);
@@ -1100,12 +1100,12 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
                             $eventLogBean->recordCertifyItemEvent($itemId, $indexId);
                         }
                     }
-                } elseif ($type['open_level'] == XOONIPS_OL_GROUP_ONLY) {
+                } elseif (XOONIPS_OL_GROUP_ONLY == $type['open_level']) {
                     $groupId = $type['groupid'];
                     $accept = $type['item_accept'];
                     $dataname = Xoonips_Enum::WORKFLOW_GROUP_ITEMS;
                     $groupAdminUids = $groupsLinkBean->getAdminUserIds($groupId);
-                    if ($accept == '1') {
+                    if ('1' == $accept) {
                         $sendToUsers = Xoonips_Workflow::getAllApproverUserIds($this->dirname, $dataname, $indexItemLinkId);
                         $sendToUsers = array_merge($sendToUsers, $groupAdminUids);
                         $sendToUsers = array_unique($sendToUsers);
@@ -1173,7 +1173,7 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
                     'indexId' => $indexId,
                     'open_level' => $index['open_level'],
                 );
-                if ($index['open_level'] == XOONIPS_OL_GROUP_ONLY) {
+                if (XOONIPS_OL_GROUP_ONLY == $index['open_level']) {
                     $groupId = $index['groupid'];
                     $groupInfo = $groupBean->getGroup($groupId);
                     if ($groupInfo['item_number_limit'] > 0 && $this->countGroupItems($groupId) >= $groupInfo['item_number_limit']) {
@@ -1202,7 +1202,7 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
                     'indexId' => $indexId,
                     'open_level' => $index['open_level'],
                 );
-                if ($index['open_level'] == XOONIPS_OL_GROUP_ONLY) {
+                if (XOONIPS_OL_GROUP_ONLY == $index['open_level']) {
                     $groupId = $index['groupid'];
                     $groupInfo = $groupBean->getGroup($groupId);
                     $info['groupid'] = $groupId;
@@ -1221,7 +1221,7 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
                     'indexId' => $indexId,
                     'open_level' => $index['open_level'],
                 );
-                if ($index['open_level'] == XOONIPS_OL_GROUP_ONLY) {
+                if (XOONIPS_OL_GROUP_ONLY == $index['open_level']) {
                     $groupId = $index['groupid'];
                     $groupInfo = $groupBean->getGroup($groupId);
                     if ($groupInfo['item_number_limit'] > 0 && $this->countGroupItems($groupId) >= $groupInfo['item_number_limit']) {
@@ -1281,10 +1281,10 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
         $result = $bean->getIndexItemLinkInfo($itemId);
         if ($result) {
             foreach ($result as $link) {
-                if ($link['certify_state'] == XOONIPS_CERTIFY_REQUIRED || $link['certify_state'] == XOONIPS_WITHDRAW_REQUIRED) {
+                if (XOONIPS_CERTIFY_REQUIRED == $link['certify_state'] || XOONIPS_WITHDRAW_REQUIRED == $link['certify_state']) {
                     return false;
                 }
-                if ($link['certify_state'] == XOONIPS_CERTIFIED && !$isModerator) {
+                if (XOONIPS_CERTIFIED == $link['certify_state'] && !$isModerator) {
                     return false;
                 }
             }
@@ -1314,10 +1314,10 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
         $result = $bean->getIndexItemLinkInfo($itemId);
         if ($result) {
             foreach ($result as $link) {
-                if ($link['certify_state'] == XOONIPS_CERTIFY_REQUIRED || $link['certify_state'] == XOONIPS_WITHDRAW_REQUIRED) {
+                if (XOONIPS_CERTIFY_REQUIRED == $link['certify_state'] || XOONIPS_WITHDRAW_REQUIRED == $link['certify_state']) {
                     return false;
                 }
-                if ($link['certify_state'] == XOONIPS_CERTIFIED && !$isModerator && !$isItemUser) {
+                if (XOONIPS_CERTIFIED == $link['certify_state'] && !$isModerator && !$isItemUser) {
                     return false;
                 }
             }
@@ -1347,16 +1347,16 @@ class Xoonips_ItemVirtualBean extends Xoonips_BeanBase
         if ($links) {
             foreach ($links as $link) {
                 $indexInfo = $indexBean->getIndex($link['index_id']);
-                if ($link['certify_state'] == XOONIPS_NOT_CERTIFIED) {
+                if (XOONIPS_NOT_CERTIFIED == $link['certify_state']) {
                     if ($isModerator || $isItemUser) {
                         $visible = true;
                     }
-                } elseif ($link['certify_state'] == XOONIPS_CERTIFY_REQUIRED || $link['certify_state'] == XOONIPS_CERTIFIED || $link['certify_state'] == XOONIPS_WITHDRAW_REQUIRED) {
-                    if ($indexInfo['open_level'] == XOONIPS_OL_PUBLIC) {
+                } elseif (XOONIPS_CERTIFY_REQUIRED == $link['certify_state'] || XOONIPS_CERTIFIED == $link['certify_state'] || XOONIPS_WITHDRAW_REQUIRED == $link['certify_state']) {
+                    if (XOONIPS_OL_PUBLIC == $indexInfo['open_level']) {
                         if ($isModerator || $isItemUser) {
                             $visible = true;
                         }
-                    } elseif ($indexInfo['open_level'] == XOONIPS_OL_GROUP_ONLY) {
+                    } elseif (XOONIPS_OL_GROUP_ONLY == $indexInfo['open_level']) {
                         $isGroupManager = $userBean->isGroupManager($indexInfo['groupid'], $uid);
                         if ($isModerator || $isItemUser || $isGroupManager) {
                             $visible = true;

--- a/xoops_trust_path/modules/xoonips/class/core/ImportItemtype.class.php
+++ b/xoops_trust_path/modules/xoonips/class/core/ImportItemtype.class.php
@@ -152,7 +152,7 @@ class Xoonips_ImportItemType
         //get XML object
         $xmlFile = $uploaddir.'/'.$itemtype.'/'.$itemtype.'.xml';
         $xmlObj = $this->getSimpleXMLElement($xmlFile);
-        if ($xmlObj === false || empty($xmlObj)) {
+        if (false === $xmlObj || empty($xmlObj)) {
             return false;
         }
 
@@ -417,7 +417,7 @@ class Xoonips_ImportItemType
                     'released' => 1,
                 );
             $link_info = $groupBean->getGroupDetailById($link['group_id'], $link['item_field_detail_id']);
-            if (count($link_info) == 0) {
+            if (0 == count($link_info)) {
                 if (!$groupBean->insertLink($link, $lid)) {
                     return false;
                 }
@@ -495,7 +495,7 @@ class Xoonips_ImportItemType
             $obj['schema_id'] = $schemaid[$obj['schema_id']];
             $obj['item_type_id'] = $map['itemtype'][$obj['item_type_id']];
             $obj['group_id'] = null;
-            if (strpos($schema, 'NIItype') != false) {
+            if (false != strpos($schema, 'NIItype')) {
                 if (in_array($obj['item_field_detail_id'], $niiTypes)) {
                     $obj['item_field_detail_id'] = $valuesetid[$schema.':'.$obj['item_field_detail_id']];
                 } else {
@@ -510,10 +510,10 @@ class Xoonips_ImportItemType
                     $obj['item_field_detail_id'] = implode(',', $detail_id_list);
                     $obj['group_id'] = implode(',', $group_id_list);
                 }
-            } elseif ($obj['item_field_detail_id'] != 'http://' && $obj['item_field_detail_id'] != 'ID'
-                && $obj['item_field_detail_id'] != 'itemtype' && $obj['item_field_detail_id'] != 'meta_author'
-                && $obj['item_field_detail_id'] != 'owner' && $obj['item_field_detail_id'] != 'full_text'
-                && $obj['item_field_detail_id'] != 'fixed_value' && !in_array($obj['item_field_detail_id'], $niiTypes)) {
+            } elseif ('http://' != $obj['item_field_detail_id'] && 'ID' != $obj['item_field_detail_id']
+                && 'itemtype' != $obj['item_field_detail_id'] && 'meta_author' != $obj['item_field_detail_id']
+                && 'owner' != $obj['item_field_detail_id'] && 'full_text' != $obj['item_field_detail_id']
+                && 'fixed_value' != $obj['item_field_detail_id'] && !in_array($obj['item_field_detail_id'], $niiTypes)) {
                 $detail_id_list = array();
                 $group_id_list = array();
                 $idlist = explode(',', $obj['item_field_detail_id']);

--- a/xoops_trust_path/modules/xoonips/class/core/Item.class.php
+++ b/xoops_trust_path/modules/xoonips/class/core/Item.class.php
@@ -93,7 +93,7 @@ class Xoonips_Item
      */
     protected function getFieldName($field, $groupLoopId, $id = null)
     {
-        if ($id == null) {
+        if (null == $id) {
             return $field->getFieldGroupId().Xoonips_Enum::ITEM_ID_SEPARATOR.$groupLoopId.Xoonips_Enum::ITEM_ID_SEPARATOR.$field->getId();
         } else {
             return $field->getFieldGroupId().Xoonips_Enum::ITEM_ID_SEPARATOR.$groupLoopId.Xoonips_Enum::ITEM_ID_SEPARATOR.$id;
@@ -410,7 +410,7 @@ class Xoonips_Item
         // insert xoonips_change_log
         $edited = false;
         $logs = $this->getChangeLogs($this->data, $itemId, $edited);
-        if ($logs != '' && !$this->insertXoonipsChangeLog($logs, $itemId)) {
+        if ('' != $logs && !$this->insertXoonipsChangeLog($logs, $itemId)) {
             return false;
         }
 
@@ -525,7 +525,7 @@ class Xoonips_Item
         $usersLinkBean = Xoonips_BeanFactory::getBean('ItemUsersLinkBean', $this->dirname, $this->trustDirname);
         $usersBean = Xoonips_BeanFactory::getBean('UsersBean', $this->dirname);
         $results = $usersLinkBean->getItemUsersInfo($itemId);
-        if ($results !== false) {
+        if (false !== $results) {
             // subtract post
             foreach ($results as $result) {
                 $usersBean->subtractPost($result['uid']);
@@ -612,7 +612,7 @@ class Xoonips_Item
     {
         $sqlStrings = array();
         $scopeSearchFlg = false;
-        if ($search_type == Xoonips_Enum::OP_TYPE_SEARCH) {
+        if (Xoonips_Enum::OP_TYPE_SEARCH == $search_type) {
             $scopeSearchFlg = true;
         }
 
@@ -630,14 +630,14 @@ class Xoonips_Item
         $basicTable = $xoopsDB->prefix($this->dirname.'_item');
         $searchTextTable = $xoopsDB->prefix($this->dirname.'_search_text');
 
-        if ($search_type == Xoonips_Enum::OP_TYPE_SEARCH) {
+        if (Xoonips_Enum::OP_TYPE_SEARCH == $search_type) {
             $detailSql = "SELECT t1.item_id FROM $basicTable t1";
             $index = 2;
             foreach ($sqlStrings as $tableNm => $strings) {
                 $tableName = $xoopsDB->prefix($tableNm);
                 $subtn = 't'.$index;
                 if ($tableNm == $this->dirname.'_item' || $tableNm == $this->dirname.'_item_title' || $tableNm == $this->dirname.'_item_keyword') {
-                    if (count($strings) == 0) {
+                    if (0 == count($strings)) {
                         $detailSql .= " INNER JOIN $tableName $subtn ON t1.item_id=$subtn.item_id AND t1.item_type_id=$itemtypeId";
                     } else {
                         foreach ($strings as $string) {
@@ -647,7 +647,7 @@ class Xoonips_Item
                         }
                     }
                 } elseif ($tableNm == $this->dirname.'_item_file') {
-                    if (count($strings) == 0) {
+                    if (0 == count($strings)) {
                         $detailSql .= " INNER JOIN $tableName $subtn ON t1.item_id=$subtn.item_id AND t1.item_type_id=$itemtypeId AND $subtn.sess_id IS NULL";
                     } else {
                         foreach ($strings as $string) {
@@ -659,7 +659,7 @@ class Xoonips_Item
                         }
                     }
                 } elseif ($tableNm == $this->dirname.'_item_users_link') {
-                    if (count($strings) == 0) {
+                    if (0 == count($strings)) {
                         $detailSql .= " INNER JOIN $tableName $subtn ON t1.item_id=$subtn.item_id AND t1.item_type_id=$itemtypeId";
                     } else {
                         foreach ($strings as $string) {
@@ -672,7 +672,7 @@ class Xoonips_Item
                         }
                     }
                 } elseif ($tableNm == $this->dirname.'_item_changelog') {
-                    if (count($strings) == 0) {
+                    if (0 == count($strings)) {
                         $detailSql .= " INNER JOIN $tableName $subtn ON t1.item_id=$subtn.item_id AND t1.item_type_id=$itemtypeId";
                     } else {
                         foreach ($strings as $string) {
@@ -682,7 +682,7 @@ class Xoonips_Item
                         }
                     }
                 } elseif ($tableNm == $this->dirname.'_item_related_to') {
-                    if (count($strings) == 0) {
+                    if (0 == count($strings)) {
                         $detailSql .= " INNER JOIN $tableName $subtn ON t1.item_id=$subtn.item_id AND t1.item_type_id=$itemtypeId";
                     } else {
                         foreach ($strings as $string) {
@@ -691,8 +691,8 @@ class Xoonips_Item
                             $detailSql .= " INNER JOIN $tableName $subtn ON t1.item_id=$subtn.item_id AND t1.item_type_id=$itemtypeId AND ".mb_ereg_replace('\\x22t1\\x22', "$subtn", $string);
                         }
                     }
-                } elseif (strncmp($tableNm, $this->dirname.'_item_extend', strlen($this->dirname) + 12) == 0) {
-                    if (count($strings) == 0) {
+                } elseif (0 == strncmp($tableNm, $this->dirname.'_item_extend', strlen($this->dirname) + 12)) {
+                    if (0 == count($strings)) {
                         $detailSql .= " INNER JOIN $tableName $subtn ON t1.item_id=$subtn.item_id AND t1.item_type_id=$itemtypeId";
                     } else {
                         foreach ($strings as $string) {
@@ -713,7 +713,7 @@ class Xoonips_Item
                 $tableName = $xoopsDB->prefix($tableNm);
                 $subtn = 't'.$index;
                 if ($tableNm == $this->dirname.'_item' || $tableNm == $this->dirname.'_item_title' || $tableNm == $this->dirname.'_item_keyword') {
-                    if (count($strings) == 0) {
+                    if (0 == count($strings)) {
                         if ($tableNm == $this->dirname.'_item') {
                             $detailSqlArr[] = "SELECT $subtn.item_id FROM $tableName $subtn WHERE $subtn.item_type_id=$itemtypeId";
                         } else {
@@ -727,7 +727,7 @@ class Xoonips_Item
                         }
                     }
                 } elseif ($tableNm == $this->dirname.'_item_file') {
-                    if (count($strings) == 0) {
+                    if (0 == count($strings)) {
                         $detailSqlArr[] = "SELECT $subtn.item_id FROM $tableName $subtn WHERE $subtn.sess_id IS NULL";
                     } else {
                         foreach ($strings as $string) {
@@ -739,7 +739,7 @@ class Xoonips_Item
                         }
                     }
                 } elseif ($tableNm == $this->dirname.'_item_users_link') {
-                    if (count($strings) == 0) {
+                    if (0 == count($strings)) {
                         $detailSqlArr[] = "SELECT $subtn.item_id FROM $tableName $subtn";
                     } else {
                         foreach ($strings as $string) {
@@ -751,7 +751,7 @@ class Xoonips_Item
                         }
                     }
                 } elseif ($tableNm == $this->dirname.'_item_changelog') {
-                    if (count($strings) == 0) {
+                    if (0 == count($strings)) {
                         $detailSqlArr[] = "SELECT $subtn.item_id FROM $tableName $subtn";
                     } else {
                         foreach ($strings as $string) {
@@ -761,11 +761,11 @@ class Xoonips_Item
                         }
                     }
                 } elseif ($tableNm == $this->dirname.'_item_related_to') {
-                    if ($search_type == Xoonips_Enum::OP_TYPE_QUICKSEARCH) {
+                    if (Xoonips_Enum::OP_TYPE_QUICKSEARCH == $search_type) {
                         continue;
                     }
 
-                    if (count($strings) == 0) {
+                    if (0 == count($strings)) {
                         $detailSqlArr[] = "SELECT $subtn.item_id FROM $tableName $subtn";
                     } else {
                         foreach ($strings as $string) {
@@ -774,8 +774,8 @@ class Xoonips_Item
                             $detailSqlArr[] = "SELECT $subtn.item_id as item_id FROM $tableName $subtn WHERE ".mb_ereg_replace('\\x22t1\\x22', "$subtn", $string);
                         }
                     }
-                } elseif (strncmp($tableNm, $this->dirname.'_item_extend', strlen($this->dirname) + 12) == 0) {
-                    if (count($strings) == 0) {
+                } elseif (0 == strncmp($tableNm, $this->dirname.'_item_extend', strlen($this->dirname) + 12)) {
+                    if (0 == count($strings)) {
                         $detailSqlArr[] = "SELECT $subtn.item_id FROM $tableName $subtn";
                     } else {
                         foreach ($strings as $string) {
@@ -788,7 +788,7 @@ class Xoonips_Item
             }
             $searchSqlStr = implode(' UNION ALL ', $detailSqlArr);
 
-            if ($itemtypeId == 0) {
+            if (0 == $itemtypeId) {
                 $detailSql = "SELECT bscTbl.item_id FROM $basicTable bscTbl INNER JOIN ( $searchSqlStr ) AS tempTbl ON bscTbl.item_id=tempTbl.item_id";
             } else {
                 $detailSql = "SELECT bscTbl.item_id FROM $basicTable bscTbl INNER JOIN ( $searchSqlStr ) AS tempTbl ON bscTbl.item_id=tempTbl.item_id AND bscTbl.item_type_id=$itemtypeId ";
@@ -910,7 +910,7 @@ class Xoonips_Item
         foreach ($newData as $key => $value) {
             if (isset($key)) {
                 $ids = explode(Xoonips_Enum::ITEM_ID_SEPARATOR, $key);
-                if (count($ids) == 3) {
+                if (3 == count($ids)) {
                     $groupId = $ids[0];
                     $detailId = $ids[2];
                     $viewType = $this->fields[$fields_cnt]->getViewType();
@@ -925,7 +925,7 @@ class Xoonips_Item
 
                     // added item
                     if (!isset($oldData[$key])) {
-                        if ($value != '') {
+                        if ('' != $value) {
                             $logs["$groupId:0"] = $this->fieldGroups[$groupId]->getName();
                             if ($viewType->getId() != $createUserView && $viewType->getId() != $indexView) {
                                 $edited = true;
@@ -947,7 +947,7 @@ class Xoonips_Item
         foreach ($oldData as $key => $value) {
             if (!isset($newData[$key])) {
                 $ids = explode(Xoonips_Enum::ITEM_ID_SEPARATOR, $key);
-                if (count($ids) == 3) {
+                if (3 == count($ids)) {
                     $groupId = $ids[0];
                     $logs["$groupId:0"] = $this->fieldGroups[$groupId]->getName();
                 }
@@ -960,7 +960,7 @@ class Xoonips_Item
     private function convertTime($str)
     {
         $ret = '';
-        if (strlen($str) == 10) {
+        if (10 == strlen($str)) {
             $int_year = intval(substr($str, 0, 4));
             $int_month = intval(substr($str, 5, 2));
             $int_day = intval(substr($str, 8, 2));
@@ -978,14 +978,14 @@ class Xoonips_Item
         foreach ($newData as $key => $value) {
             if (isset($key)) {
                 $ids = explode(Xoonips_Enum::ITEM_ID_SEPARATOR, $key);
-                if (count($ids) == 3) {
+                if (3 == count($ids)) {
                     $detailId = $ids[2];
                     $viewType = $this->fields[$fields_cnt]->getViewType();
                     ++$fields_cnt;
                     if (!$viewType->isIndex()) {
                         // added item
                         if (!isset($oldData[$key])) {
-                            if ($value != '') {
+                            if ('' != $value) {
                                 return true;
                             }
                             // updated item
@@ -1001,7 +1001,7 @@ class Xoonips_Item
         foreach ($oldData as $key => $value) {
             if (!isset($newData[$key])) {
                 $ids = explode(Xoonips_Enum::ITEM_ID_SEPARATOR, $key);
-                if (count($ids) == 3) {
+                if (3 == count($ids)) {
                     $detailId = $ids[2];
                     $viewType = $this->fields[$detailId]->getViewType();
                     if (!$viewType->isIndex()) {
@@ -1059,7 +1059,7 @@ class Xoonips_Item
         $columns = '';
         $values = '';
         foreach ($strings as $column => $v) {
-            if ($column == 'doi') {
+            if ('doi' == $column) {
                 $setkey = $column.'='.$v[0].', ';
             }
         }
@@ -1148,7 +1148,7 @@ class Xoonips_Item
         $usersLinkBean = Xoonips_BeanFactory::getBean('ItemUsersLinkBean', $this->dirname, $this->trustDirname);
         $usersBean = Xoonips_BeanFactory::getBean('UsersBean', $this->dirname);
         $changedUids = $usersLinkBean->getUserChangeInfo($itemId, $uids);
-        if ($changedUids === false) {
+        if (false === $changedUids) {
             return false;
         }
         // add user
@@ -1174,7 +1174,7 @@ class Xoonips_Item
                 $user = $usersBean->getUserBasicInfo($uid);
                 $userNames = $userNames.$user['uname'].',';
             }
-            if ($userNames != '') {
+            if ('' != $userNames) {
                 $userNames = substr($userNames, 0, strlen($userNames) - 1);
             }
             //send to item user
@@ -1183,7 +1183,7 @@ class Xoonips_Item
             foreach ($itemUsersInfo as $itemUser) {
                 $itemUsersId[] = $itemUser['uid'];
             }
-            if ($itemUsersId != false && count($itemUsersId) != 0) {
+            if (false != $itemUsersId && 0 != count($itemUsersId)) {
                 $this->notification->userAddItemUser($itemId, $userNames, $itemUsersId);
             }
         }
@@ -1204,7 +1204,7 @@ class Xoonips_Item
                 $itemUsersId[] = $uid;
                 $log->recordDeleteItemUserEvent($itemId, $uid);
             }
-            if ($userNames != '') {
+            if ('' != $userNames) {
                 $userNames = substr($userNames, 0, strlen($userNames) - 1);
             }
             //send to item user
@@ -1213,7 +1213,7 @@ class Xoonips_Item
                 $itemUsersId[] = $itemUser['uid'];
             }
 
-            if ($itemUsersId != false && count($itemUsersId) != 0) {
+            if (false != $itemUsersId && 0 != count($itemUsersId)) {
                 $this->notification->userDeleteItemUser($itemId, $userNames, $itemUsersId);
             }
         }
@@ -1234,7 +1234,7 @@ class Xoonips_Item
         $indexLinkBean = Xoonips_BeanFactory::getBean('IndexItemLinkBean', $this->dirname, $this->trustDirname);
         $usersBean = Xoonips_BeanFactory::getBean('ItemUsersLinkBean', $this->dirname, $this->trustDirname);
         $changedUids = $usersBean->getUserChangeInfo($itemId, $uids);
-        if ($changedUids === false) {
+        if (false === $changedUids) {
             return false;
         }
         // add user
@@ -1284,7 +1284,7 @@ class Xoonips_Item
         foreach ($data as $key => $value) {
             if (isset($key)) {
                 $ids = explode(Xoonips_Enum::ITEM_ID_SEPARATOR, $key);
-                if (count($ids) == 3) {
+                if (3 == count($ids)) {
                     $detailId = $ids[2];
                     $field = $this->fields[$detailId];
                     if ($field->getViewType()->isCreateUser()) {
@@ -1302,7 +1302,7 @@ class Xoonips_Item
     {
         $usersBean = Xoonips_BeanFactory::getBean('ItemUsersLinkBean', $this->dirname, $this->trustDirname);
         $changedUids = $usersBean->getUserChangeInfo($itemId, $uids);
-        if ($changedUids === false) {
+        if (false === $changedUids) {
             return false;
         }
         $changedFlg = false;
@@ -1393,7 +1393,7 @@ class Xoonips_Item
         foreach ($strings as $column => $v) {
             $columns = 'item_field_detail_id, title_id, title, item_id';
             $title = $v[0];
-            if (trim($title) != '' && trim($title) != "''") {
+            if ('' != trim($title) && "''" != trim($title)) {
                 $values = "$column, $loop, $title, $itemId";
                 $sql = "insert into $table ($columns) values ($values)";
                 if (!$xoopsDB->queryF($sql)) {
@@ -1420,7 +1420,7 @@ class Xoonips_Item
             $columns = 'item_id, keyword_id, keyword';
             $loop = 1;
             foreach ($values as $v) {
-                if (trim($v) != '' && trim($v) != "''") {
+                if ('' != trim($v) && "''" != trim($v)) {
                     $sql = sprintf('insert into %s (%s) values (%u, %u, %s)', $table, $columns, $itemId, $loop, Xoonips_Utils::convertSQLStr($v));
                     if (!$xoopsDB->queryF($sql)) {
                         return false;
@@ -1444,7 +1444,7 @@ class Xoonips_Item
         $loop = 1;
         $temp = '';
         foreach ($strings as $column => $v) {
-            if (empty($column) || $column == 'caption') {
+            if (empty($column) || 'caption' == $column) {
                 continue;
             }
 
@@ -1490,7 +1490,7 @@ class Xoonips_Item
         }
 
         foreach ($strings as $column => $v) {
-            if (empty($column) || $column == 'caption') {
+            if (empty($column) || 'caption' == $column) {
                 continue;
             }
 
@@ -1584,7 +1584,7 @@ class Xoonips_Item
         $ret = true;
         $itemExtendBean = Xoonips_BeanFactory::getBean('ItemExtendBean', $this->dirname, $this->trustDirname);
         foreach ($sqlStrings as $tableName => $strings) {
-            if (strpos($tableName, 'item_extend') !== false) {
+            if (false !== strpos($tableName, 'item_extend')) {
                 foreach ($strings as $groupid => $columns) {
                     if (!$itemExtendBean->delete($itemId, $tableName, $groupid)) {
                         return false;
@@ -1592,7 +1592,7 @@ class Xoonips_Item
                     foreach ($columns as $column => $values) {
                         $loop = 1;
                         foreach ($values as $v) {
-                            if (trim($v) != '' && trim($v) != "''") {
+                            if ('' != trim($v) && "''" != trim($v)) {
                                 if (!$itemExtendBean->insert($itemId, $tableName, $v, $loop, $groupid)) {
                                     return false;
                                 }
@@ -1630,7 +1630,7 @@ class Xoonips_Item
             } elseif ($tblIndex == $this->dirname.'_item_users_link') {
                 $retKey = '';
                 foreach ($this->fields as $field) {
-                    if ($field->getColumnName() == 'uid') {
+                    if ('uid' == $field->getColumnName()) {
                         $retKey = $this->getFieldName($field, 1);
                         break;
                     }
@@ -1640,11 +1640,11 @@ class Xoonips_Item
                     $uids[] = $val['uid'];
                 }
                 $ret[$retKey] = implode(',', $uids);
-                // xoonips_item_related_to
+            // xoonips_item_related_to
             } elseif ($tblIndex == $this->dirname.'_item_related_to') {
                 $retKey = '';
                 foreach ($this->fields as $field) {
-                    if ($field->getColumnName() == 'child_item_id') {
+                    if ('child_item_id' == $field->getColumnName()) {
                         $retKey = $this->getFieldName($field, 1);
                         break;
                     }
@@ -1654,7 +1654,7 @@ class Xoonips_Item
                     $iids[] = $val['child_item_id'];
                 }
                 $ret[$retKey] = implode(',', $iids);
-                // xoonips_item_title
+            // xoonips_item_title
             } elseif ($tblIndex == $this->dirname.'_item_title') {
                 foreach ($values as $val) {
                     $retKey = '';
@@ -1700,7 +1700,7 @@ class Xoonips_Item
                 // xoonips_index_item_link
             } elseif ($tblIndex == $this->dirname.'_index_item_link') {
                 foreach ($this->fields as $field) {
-                    if ($field->getColumnName() == 'index_id') {
+                    if ('index_id' == $field->getColumnName()) {
                         $retKey = $this->getFieldName($field, 1);
                         break;
                     }
@@ -1718,7 +1718,7 @@ class Xoonips_Item
                 // xoonips_item_changelog
             } elseif ($tblIndex == $this->dirname.'_item_changelog') {
                 foreach ($this->fields as $field) {
-                    if ($field->getColumnName() == 'log') {
+                    if ('log' == $field->getColumnName()) {
                         $retKey = $this->getFieldName($field, 1);
                         break;
                     }
@@ -1731,7 +1731,7 @@ class Xoonips_Item
             }
 
             // xoonips_item_extend[999]
-            if (strncmp($tblIndex, $this->dirname.'_item_extend', strlen($this->dirname) + 12) == 0) {
+            if (0 == strncmp($tblIndex, $this->dirname.'_item_extend', strlen($this->dirname) + 12)) {
                 $detailId = substr($tblIndex, strlen($this->dirname) + 12, strlen($tblIndex) - strlen($this->dirname) - 12);
                 foreach ($values as $val) {
                     $retKey = '';
@@ -1808,7 +1808,7 @@ class Xoonips_Item
                 $field = $this->fields[$index];
                 $tmpdb = $this->dbData;
                 $tbl = $field->getTableName();
-                if (!is_null($group_id) && strpos($tbl, 'xoonips_item_extend') !== false) {
+                if (!is_null($group_id) && false !== strpos($tbl, 'xoonips_item_extend')) {
                     foreach ($tmpdb[$tbl] as $index => &$distinct_tbl) {
                         if ($distinct_tbl['group_id'] !== $group_id) {
                             unset($tmpdb[$tbl][$index]);

--- a/xoops_trust_path/modules/xoonips/class/core/ItemEntity.class.php
+++ b/xoops_trust_path/modules/xoonips/class/core/ItemEntity.class.php
@@ -29,7 +29,7 @@ class Xoonips_ItemEntity
     public function get($groupXmlTag, $detailXmlTag)
     {
         $ret = false;
-        if ($this->data == null) {
+        if (null == $this->data) {
             return false;
         }
         $itemTypeId = $this->data[$this->dirname.'_item_type']['item_type_id'];
@@ -52,7 +52,7 @@ class Xoonips_ItemEntity
 
     public function getItemId()
     {
-        if ($this->data == null) {
+        if (null == $this->data) {
             return false;
         }
 
@@ -61,7 +61,7 @@ class Xoonips_ItemEntity
 
     public function getItemDoi()
     {
-        if ($this->data == null) {
+        if (null == $this->data) {
             return false;
         }
         $doi = $this->data[$this->dirname.'_item']['doi'];
@@ -74,7 +74,7 @@ class Xoonips_ItemEntity
 
     public function getItemUrl()
     {
-        if ($this->data == null) {
+        if (null == $this->data) {
             return false;
         }
 
@@ -86,7 +86,7 @@ class Xoonips_ItemEntity
 
     public function getItemTypeId()
     {
-        if ($this->data == null) {
+        if (null == $this->data) {
             return false;
         }
 
@@ -95,7 +95,7 @@ class Xoonips_ItemEntity
 
     public function getItemTypeIconName()
     {
-        if ($this->data == null) {
+        if (null == $this->data) {
             return false;
         }
 
@@ -106,7 +106,7 @@ class Xoonips_ItemEntity
     {
         $data = $this->getData($this->dirname.'_index_item_link');
         foreach ($data as $value) {
-            if ($value['certify_state'] == 1 || $value['certify_state'] == 3) {
+            if (1 == $value['certify_state'] || 3 == $value['certify_state']) {
                 return true;
             }
         }
@@ -127,7 +127,7 @@ class Xoonips_ItemEntity
     {
         $ret = false;
         $itemField = $this->getPreviewField();
-        if ($itemField != false) {
+        if (false != $itemField) {
             $data = $this->getData($this->dirname.'_item_file');
             foreach ($data as $value) {
                 $fileId = null;
@@ -140,7 +140,7 @@ class Xoonips_ItemEntity
             }
         }
 
-        if ($ret == false) {
+        if (false == $ret) {
             $icon = $this->data[$this->dirname.'_item_type']['icon'];
             $ret = XOOPS_URL."/modules/$this->dirname/images/$icon";
         }
@@ -155,7 +155,7 @@ class Xoonips_ItemEntity
         $itemFields = $itemFieldManager->getFields();
         foreach ($itemFields as $itemField) {
             // if preview view type
-            if ($itemField->getViewType()->getModule() == 'ViewTypePreview') {
+            if ('ViewTypePreview' == $itemField->getViewType()->getModule()) {
                 return $itemField;
             }
         }
@@ -175,10 +175,10 @@ class Xoonips_ItemEntity
         $beanList[$this->dirname.'_index_item_link'] = array('IndexItemLinkBean', 'getIndexItemLinkInfo');
         $beanList[$this->dirname.'_item_changelog'] = array('ItemChangeLogBean', 'getChangeLogs');
         $info = array();
-        if (strncmp($table, $this->dirname.'_item_extend', strlen($this->dirname) + 12) == 0) {
+        if (0 == strncmp($table, $this->dirname.'_item_extend', strlen($this->dirname) + 12)) {
             $itemExtendBean = Xoonips_BeanFactory::getBean('ItemExtendBean', $this->dirname, $this->trustDirname);
             $info = $itemExtendBean->getItemExtendInfo($this->item_id, $table, $this->item_gid);
-        } elseif (strncmp($table, $this->dirname.'_item_file', strlen($this->dirname) + 12) == 0) {
+        } elseif (0 == strncmp($table, $this->dirname.'_item_file', strlen($this->dirname) + 12)) {
             $fileBean = Xoonips_BeanFactory::getBean('ItemFileBean', $this->dirname, $this->trustDirname);
             $info = $fileBean->getFilesByItemId($this->item_id, $this->item_gid);
         } else {

--- a/xoops_trust_path/modules/xoonips/class/core/ItemField.class.php
+++ b/xoops_trust_path/modules/xoonips/class/core/ItemField.class.php
@@ -34,39 +34,39 @@ class Xoonips_ItemField extends Xoonips_Field
         $ret = true;
         $viewType = $this->getViewType();
 
-        if ($viewType->isDisplay($op) == false) {
+        if (false == $viewType->isDisplay($op)) {
             return false;
         }
 
         // $op(1:list 2:detail 3:search)
         switch ($op) {
         case Xoonips_Enum::OP_TYPE_LIST:
-            if ($this->getListDisplay() == 0) {
+            if (0 == $this->getListDisplay()) {
                 $ret = false;
             }
             break;
         case Xoonips_Enum::OP_TYPE_DETAIL:
-            if ($this->getDetailDisplay() == 0) {
+            if (0 == $this->getDetailDisplay()) {
                 $ret = false;
             }
             break;
         case Xoonips_Enum::OP_TYPE_METAINFO:
-            if ($this->getDetailDisplay() == 0) {
+            if (0 == $this->getDetailDisplay()) {
                 $ret = false;
             }
             break;
         case Xoonips_Enum::OP_TYPE_ITEMUSERSEDIT:
-            if ($this->getDetailDisplay() == 0) {
+            if (0 == $this->getDetailDisplay()) {
                 $ret = false;
             }
             break;
         case Xoonips_Enum::OP_TYPE_SEARCH:
-            if ($this->getDetailTarget() == 0) {
+            if (0 == $this->getDetailTarget()) {
                 $ret = false;
             }
             break;
         case Xoonips_Enum::OP_TYPE_SIMPLESEARCH:
-            if ($this->getDetailTarget() == 0) {
+            if (0 == $this->getDetailTarget()) {
                 $ret = false;
             }
             break;

--- a/xoops_trust_path/modules/xoonips/class/core/Metadata.class.php
+++ b/xoops_trust_path/modules/xoonips/class/core/Metadata.class.php
@@ -50,14 +50,14 @@ class Xoonips_Metadata
     {
         $lines = array();
         // if junii2
-        if ($this->metadataPrefix == 'junii2') {
+        if ('junii2' == $this->metadataPrefix) {
             $lines[] = '<metadata>';
             $lines[] = '<junii2 xmlns="http://irdb.nii.ac.jp/oai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://irdb.nii.ac.jp/oai http://irdb.nii.ac.jp/oai/junii2-3-1.xsd">';
             $this->getContents($item_type_id, $item_id, $lines);
             $lines[] = '</junii2>';
             $lines[] = '</metadata>';
-            // if oai_dc
-        } elseif ($this->metadataPrefix == 'oai_dc') {
+        // if oai_dc
+        } elseif ('oai_dc' == $this->metadataPrefix) {
             $lines[] = '<metadata>';
             $lines[] = '<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">';
             $this->getContents($item_type_id, $item_id, $lines);
@@ -70,7 +70,7 @@ class Xoonips_Metadata
 
     public static function supportMetadataFormat($metadataPrefix)
     {
-        if ($metadataPrefix == 'oai_dc' || $metadataPrefix == 'junii2') {
+        if ('oai_dc' == $metadataPrefix || 'junii2' == $metadataPrefix) {
             return true;
         }
 
@@ -99,31 +99,31 @@ class Xoonips_Metadata
                                 break;
                             }
                         }
-                        if ($valueset == false) {
+                        if (false == $valueset) {
                             $itemBean = Xoonips_BeanFactory::getBean('ItemBean', $this->dirname, $this->trustDirname);
                             $item = $itemBean->getItemBasicInfo($item_id);
                             $doi = $item['doi'];
-                            if ($detail_id == 'http://') {
+                            if ('http://' == $detail_id) {
                                 $itemObj = &$this->itemHandler->get($item_id);
                                 $metadata[] = $itemObj->getUrl();
-                            } elseif ($detail_id == 'ID') {
+                            } elseif ('ID' == $detail_id) {
                                 $database_id = Functions::getXoonipsConfig($this->dirname, XOONIPS_CONFIG_REPOSITORY_NIJC_CODE);
-                                if ($doi == null) {
+                                if (null == $doi) {
                                     $metadata[] = "$database_id/$item_type_id.$item_id";
                                 } else {
                                     $metadata[] = "$database_id:".XOONIPS_CONFIG_DOI_FIELD_PARAM_NAME."/$doi";
                                 }
-                            } elseif ($detail_id == 'meta_author') {
+                            } elseif ('meta_author' == $detail_id) {
                                 $moduleHandler = &xoops_gethandler('module');
                                 $legacyRender = &$moduleHandler->getByDirname('legacyRender');
                                 $configHandler = &xoops_gethandler('config');
                                 $configs = &$configHandler->getConfigsByCat(0, $legacyRender->get('mid'));
                                 $metadata[] = $configs['meta_author'];
-                            } elseif ($detail_id == 'itemtype') {
+                            } elseif ('itemtype' == $detail_id) {
                                 $itemTypeBean = Xoonips_BeanFactory::getBean('ItemTypeBean', $this->dirname, $this->trustDirname);
                                 $itemTypeInfo = $itemTypeBean->getItemTypeInfo($item_type_id);
                                 $metadata[] = $itemTypeInfo['name'];
-                            } elseif ($detail_id == 'owner') {
+                            } elseif ('owner' == $detail_id) {
                                 $itemUsersBean = Xoonips_BeanFactory::getBean('ItemUsersLinkBean', $this->dirname, $this->trustDirname);
                                 $itemUsersInfo = $itemUsersBean->getItemUsersInfo($item_id);
                                 $userBean = Xoonips_BeanFactory::getBean('UsersBean', $this->dirname, $this->trustDirname);
@@ -135,26 +135,26 @@ class Xoonips_Metadata
                                         $metadata[] = $owner['uname'];
                                     }
                                 }
-                            } elseif ($detail_id == 'full_text') {
+                            } elseif ('full_text' == $detail_id) {
                                 $fileBean = Xoonips_BeanFactory::getBean('ItemFileBean', $this->dirname, $this->trustDirname);
                                 $fileInfo = $fileBean->getFilesByItemId($item_id);
                                 if (count($fileInfo) > 0) {
                                     foreach ($fileInfo as $file) {
-                                        if ($file['mime_type'] != 'application/pdf') {
+                                        if ('application/pdf' != $file['mime_type']) {
                                             continue;
                                         }
                                         $itemFileObj = &$this->itemFileHandler->get($file['file_id']);
                                         $metadata[] = $itemFileObj->getDownloadUrl(2);
                                     }
                                 }
-                            } elseif ($detail_id == 'fixed_value') {
+                            } elseif ('fixed_value' == $detail_id) {
                                 if (!empty($link['value'])) {
                                     $metadata[] = $link['value'];
                                 }
                             } else {
                                 $group_id = $group_ids[$index];
                                 $temp = $itemtype->getMetadata($detail_id, $group_id);
-                                if ($schema['name'] == 'format') {
+                                if ('format' == $schema['name']) {
                                     if (is_array($temp)) {
                                         $metadata[] = $temp[1];
                                     } else {
@@ -192,9 +192,9 @@ class Xoonips_Metadata
                         $temp = self::convert($metadata, $link['value']);
                         $temp = StringUtils::convertEncoding($temp, 'UTF-8', _CHARSET, 'h');
                     }
-                    if ($temp != 'null') {
+                    if ('null' != $temp) {
                         if (strlen($temp) > 0) {
-                            if (strcmp($schema['metadata_prefix'], 'oai_dc') == 0 && strcmp($schema['name'], 'type:NIItype') == 0) {
+                            if (0 == strcmp($schema['metadata_prefix'], 'oai_dc') && 0 == strcmp($schema['name'], 'type:NIItype')) {
                                 $lines[] = '<type>NIIType:'.StringUtils::xmlSpecialChars($temp, _CHARSET).'</type>';
                             } else {
                                 $lines[] = '<'.$schema['name'].'>'.StringUtils::xmlSpecialChars($temp, _CHARSET).'</'.$schema['name'].'>';
@@ -203,7 +203,7 @@ class Xoonips_Metadata
                             foreach ($metadata as $m) {
                                 if (!empty($m)) {
                                     $m = StringUtils::convertEncoding($m, 'UTF-8', _CHARSET, 'h');
-                                    if (strcmp($schema['metadata_prefix'], 'oai_dc') == 0 && strcmp($schema['name'], 'type:NIItype') == 0) {
+                                    if (0 == strcmp($schema['metadata_prefix'], 'oai_dc') && 0 == strcmp($schema['name'], 'type:NIItype')) {
                                         $lines[] = '<type>NIIType:'.StringUtils::xmlSpecialChars($m, _CHARSET).'</type>';
                                     } else {
                                         $lines[] = '<'.$schema['name'].'>'.StringUtils::xmlSpecialChars($m, _CHARSET).'</'.$schema['name'].'>';
@@ -212,7 +212,7 @@ class Xoonips_Metadata
                             }
                         }
                     }
-                } elseif ($flg == true) {
+                } elseif (true == $flg) {
                     break;
                 }
             }
@@ -222,10 +222,10 @@ class Xoonips_Metadata
     private static function convert($metadata, $convertString)
     {
         //return fixed value
-        if (strcmp($metadata[0], $convertString) == 0) {
+        if (0 == strcmp($metadata[0], $convertString)) {
             return $metadata[0];
         }
-        if ($convertString != '') {
+        if ('' != $convertString) {
             preg_match_all("/@(\d+)/", $convertString, $matches);
             if (empty($matches[0])) {
                 return false;
@@ -239,7 +239,7 @@ class Xoonips_Metadata
             eval(" \$ret = $convertString");
         }
 
-        if ($ret == null) {
+        if (null == $ret) {
             $ret = 'null';
         }
 

--- a/xoops_trust_path/modules/xoonips/class/core/Notification.class.php
+++ b/xoops_trust_path/modules/xoonips/class/core/Notification.class.php
@@ -13,7 +13,7 @@ require_once __DIR__.'/Workflow.class.php';
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function createMessageSignTemplate($resource_type, $resource_name, &$template_source, &$template_timestamp, &$smarty_obj)
 {
-    if ($resource_type != 'messagesign') {
+    if ('messagesign' != $resource_type) {
         return false;
     }
     $parameter = explode(',', $resource_name);
@@ -167,19 +167,19 @@ class Xoonips_Notification extends XoopsNotificationHandler
     {
         $itemBasicBean = Xoonips_BeanFactory::getBean('ItemBean', $this->dirname, $this->trustDirname);
         $item_basic = $itemBasicBean->getItemBasicInfo($item_id);
-        if ($item_basic === false) {
+        if (false === $item_basic) {
             return false;
         }
 
         $itemTypeBean = Xoonips_BeanFactory::getBean('ItemTypeBean', $this->dirname, $this->trustDirname);
         $item_type = $itemTypeBean->getItemTypeInfo($item_basic['item_type_id']);
-        if ($item_type === false) {
+        if (false === $item_type) {
             return false;
         }
 
         $itemTitleBean = Xoonips_BeanFactory::getBean('ItemTitleBean', $this->dirname, $this->trustDirname);
         $titles = $itemTitleBean->getItemTitleInfo($item_id);
-        if ($titles === false) {
+        if (false === $titles) {
             return false;
         }
 
@@ -187,7 +187,7 @@ class Xoonips_Notification extends XoopsNotificationHandler
 
         $itemUsersBean = Xoonips_BeanFactory::getBean('ItemUsersLinkBean', $this->dirname, $this->trustDirname);
         $itemUsersInfo = $itemUsersBean->getItemUsersInfo($item_id);
-        if ($itemUsersInfo === false) {
+        if (false === $itemUsersInfo) {
             return false;
         }
         $itemUsersName = array();
@@ -195,7 +195,7 @@ class Xoonips_Notification extends XoopsNotificationHandler
         foreach ($itemUsersInfo as $itemUser) {
             $xoops_user = $userBean->getUserBasicInfo($itemUser['uid']);
             $itemName = '';
-            if ($xoops_user['name'] != '') {
+            if ('' != $xoops_user['name']) {
                 $itemName = '('.$xoops_user['name'].')';
             }
             $itemUsersUname[] = $xoops_user['uname'].$itemName;
@@ -203,7 +203,7 @@ class Xoonips_Notification extends XoopsNotificationHandler
 
         $keywordBean = Xoonips_BeanFactory::getBean('ItemKeywordBean', $this->dirname, $this->trustDirname);
         $keywords = $keywordBean->getKeywords($item_id);
-        if ($keywords === false) {
+        if (false === $keywords) {
             return false;
         }
 
@@ -534,7 +534,7 @@ class Xoonips_Notification extends XoopsNotificationHandler
                 'OLD_INDEX_PATH' => $context['old_index_path'],
                 'NEW_INDEX_PATH' => $new_index_path,
                 'LISTITEM_URL' => XOOPS_URL.'/modules/'.$this->dirname
-                 .'/list.php?index_id='.$parentIndexId,
+                 .'/'.Functions::getItemListUrl($this->dirname).'?index_id='.$parentIndexId,
                 'ITEM_LIST' => implode("\n\n", $item_list),
             );
             $tags['SITENAME'] = XoopsUtils::getXoopsConfig('sitename');
@@ -608,13 +608,13 @@ class Xoonips_Notification extends XoopsNotificationHandler
     {
         $fileBean = Xoonips_BeanFactory::getBean('ItemFileBean', $this->dirname, $this->trustDirname);
         $file = $fileBean->getFile($file_id);
-        if ($file === false || count($file) === 0) {
+        if (false === $file || 0 === count($file)) {
             return;
         }
 
         $userBean = Xoonips_BeanFactory::getBean('UsersBean', $this->dirname);
         $user = $userBean->getUserBasicInfo($downloader_uid);
-        if ($user === false || count($user) === 0) {
+        if (false === $user || 0 === count($user)) {
             return;
         }
 

--- a/xoops_trust_path/modules/xoonips/class/handler/ItemFile.class.php
+++ b/xoops_trust_path/modules/xoonips/class/handler/ItemFile.class.php
@@ -118,45 +118,4 @@ class Xoonips_ItemFileHandler extends XoopsObjectGenericHandler
 
         return $ret;
     }
-
-    /**
-     * get most downloaded item object.
-     *
-     * @param int $limit
-     * @param int $term
-     *
-     * @return $ret
-     */
-    public function &getMostDownloadedItems($limit, $term)
-    {
-        $ret = array();
-        $tableItem = $this->db->prefix($this->mDirname.'_item');
-        $tableItemTitle = $this->db->prefix($this->mDirname.'_item_title');
-        $tableIndex = $this->db->prefix($this->mDirname.'_index');
-        $tableIndexItemLink = $this->db->prefix($this->mDirname.'_index_item_link');
-        if ($limit < 1) {
-            return;
-        }
-
-        $sql = sprintf('SELECT * FROM `%1$s` INNER JOIN `%2$s` ON `%1$s`.`item_id` = `%2$s`.`item_id` INNER JOIN `%3$s` ON `%1$s`.`item_id` = `%3$s`.`item_id` WHERE `%1$s`.`item_id` IN (SELECT DISTINCT `%5$s`.`item_id` FROM `%5$s` WHERE (`%5$s`.`certify_state` = %7$d OR `%5$s`.`certify_state` = %8$d) AND `%5$s`.`index_id` IN (SELECT `%4$s`.`index_id` FROM `%4$s` WHERE `%4$s`.`open_level` = %6$d)) AND ', $this->mTable, $tableItem, $tableItemTitle, $tableIndex, $tableIndexItemLink, XOONIPS_OL_PUBLIC, XOONIPS_CERTIFIED, XOONIPS_WITHDRAW_REQUIRED);
-        if ($term != 0) {
-            $sql .= sprintf('`%1$s`.`last_update_date` >= %2$d AND ', $tableItem, $term);
-        }
-        $sql .= sprintf('`%1$s`.`download_count` != 0 ORDER BY `%1$s`.`download_count` DESC limit %2$d', $this->mTable, $limit);
-
-        if ($result = $this->db->query($sql)) {
-            while ($row = $this->db->fetchArray($result)) {
-                $r = array();
-                $r['title'] = $row['title'];
-                $r['download_count'] = $row['download_count'];
-                $itemHandler = Functions::getXoonipsHandler('Item', $this->mDirname);
-                $itemObj = &$itemHandler->get($row['item_id']);
-                $r['url'] = $itemObj->getUrl();
-                unset($itemObj);
-                $ret[] = $r;
-            }
-        }
-
-        return $ret;
-    }
 }

--- a/xoops_trust_path/modules/xoonips/class/handler/ItemQuickSearchCondition.class.php
+++ b/xoops_trust_path/modules/xoonips/class/handler/ItemQuickSearchCondition.class.php
@@ -84,7 +84,7 @@ class Xoonips_ItemQuickSearchConditionHandler extends XoopsObjectGenericHandler
     public function delete(&$obj, $force = false)
     {
         $pid = $obj->get($this->mPrimary);
-        if ($pid == 1) {
+        if (1 == $pid) {
             return false;
         } // don't delete quick search condtion 'All'
         if (!parent::delete($obj, $force)) {
@@ -132,7 +132,7 @@ class Xoonips_ItemQuickSearchConditionHandler extends XoopsObjectGenericHandler
     public function getConditions()
     {
         static $cache = null;
-        if ($cache != null) {
+        if (null != $cache) {
             return $cache;
         }
         $criteria = new CriteriaElement();
@@ -175,7 +175,7 @@ class Xoonips_ItemQuickSearchConditionHandler extends XoopsObjectGenericHandler
     {
         $ret = array();
         $pid = $obj->get($this->mPrimary);
-        if ($pid == 1) {
+        if (1 == $pid) {
             // return all field ids if condition_id is 1
             $handler = Functions::getXoonipsHandler('ItemField', $this->mDirname);
             $objs = $handler->getObjectsForQuickSearch();
@@ -207,7 +207,7 @@ class Xoonips_ItemQuickSearchConditionHandler extends XoopsObjectGenericHandler
     {
         $ret = true;
         $pid = $obj->get($this->mPrimary);
-        if ($pid == 1) {
+        if (1 == $pid) {
             // allways success if condition_id is 1
             return true;
         }
@@ -264,10 +264,10 @@ class Xoonips_ItemQuickSearchConditionHandler extends XoopsObjectGenericHandler
     {
         $sql = sprintf('DELETE FROM `%s`', $this->mTableDetail);
         $where = array();
-        if ($cId !== false) {
+        if (false !== $cId) {
             $where[] = sprintf('`condition_id`=%u', $cId);
         }
-        if ($dId !== false) {
+        if (false !== $dId) {
             $where[] = sprintf('`item_field_detail_id`=%u', $dId);
         }
         if (!empty($where)) {

--- a/xoops_trust_path/modules/xoonips/class/viewtype/ViewTypeFileUpload.class.php
+++ b/xoops_trust_path/modules/xoonips/class/viewtype/ViewTypeFileUpload.class.php
@@ -25,7 +25,7 @@ class Xoonips_ViewTypeFileUpload extends Xoonips_ViewType
         }
         $fileBean = Xoonips_BeanFactory::getBean('ItemFileBean', $this->dirname, $this->trustDirname);
         if (!empty($value)) {
-            if ($fileId == 'none') {
+            if ('none' == $fileId) {
                 $fileId = $value;
             } else {
                 $fileBean->delete($value);
@@ -51,7 +51,7 @@ class Xoonips_ViewTypeFileUpload extends Xoonips_ViewType
             $file = new Xoonips_File($this->dirname, $this->trustDirname, true);
             $fileId = $file->uploadFile($fileName, 'upload', 0, $field->getId(), $field->getFieldGroupId());
             //upload_max_filesize check
-            if ($fileId == 'none') {
+            if ('none' == $fileId) {
                 $fileId = -1;
             }
         } else {
@@ -80,7 +80,7 @@ class Xoonips_ViewTypeFileUpload extends Xoonips_ViewType
         }
         $fileBean = Xoonips_BeanFactory::getBean('ItemFileBean', $this->dirname, $this->trustDirname);
         if (!empty($value)) {
-            if ($fileId == 'none') {
+            if ('none' == $fileId) {
                 $fileId = $value;
             } else {
                 $fileBean->delete($value);
@@ -108,7 +108,7 @@ class Xoonips_ViewTypeFileUpload extends Xoonips_ViewType
             $fileBean = Xoonips_BeanFactory::getBean('ItemFileBean', $this->dirname, $this->trustDirname);
             $fileInfo = $fileBean->getFileInformation($value);
             $file = $fileBean->getFile($value);
-            if ($file !== false) {
+            if (false !== $file) {
                 $itemBean = Xoonips_BeanFactory::getBean('ItemVirtualBean', $this->dirname, $this->trustDirname);
                 $notify = $itemBean->getDownloadNotify($file['item_id'], $field->getItemTypeId());
                 $rights = $itemBean->getRights($file['item_id'], $field->getItemTypeId());
@@ -118,12 +118,12 @@ class Xoonips_ViewTypeFileUpload extends Xoonips_ViewType
             $uid = is_object($xoopsUser) ? $xoopsUser->getVar('uid') : XOONIPS_UID_GUEST;
             $newFileInfo = array();
             foreach ($fileInfo as $file) {
-                if ($file === false || ($rights === false && ($notify === false || $notify == '0'))) {
+                if (false === $file || (false === $rights && (false === $notify || '0' == $notify))) {
                     $file['notify'] = false;
                 } else {
                     $file['notify'] = true;
                 }
-                if ($file === false || ($uid == XOONIPS_UID_GUEST && $limit === false)) {
+                if (false === $file || (XOONIPS_UID_GUEST == $uid && false === $limit)) {
                     $file['limit'] = false;
                 } else {
                     $file['limit'] = true;
@@ -157,7 +157,7 @@ class Xoonips_ViewTypeFileUpload extends Xoonips_ViewType
 
     public function isDisplay($op)
     {
-        if ($op == Xoonips_Enum::OP_TYPE_METAINFO) {
+        if (Xoonips_Enum::OP_TYPE_METAINFO == $op) {
             return false;
         } //hidden when metainfo form
         return true;
@@ -165,7 +165,7 @@ class Xoonips_ViewTypeFileUpload extends Xoonips_ViewType
 
     public function mustCheck(&$errors, $field, $value, $fieldName)
     {
-        if ($field->getEssential() == 1 && $value == '') {
+        if (1 == $field->getEssential() && '' == $value) {
             $fileName = $fieldName;
             $request = new Xoonips_Request();
             $file = $request->getFile($fileName);
@@ -253,10 +253,10 @@ class Xoonips_ViewTypeFileUpload extends Xoonips_ViewType
             $tableData = array();
             $sqlStrings[$tableName] = &$tableData;
         }
-        if ($value != '') {
+        if ('' != $value) {
             $query1 = $this->search->getSearchSql('original_file_name', $value, _CHARSET, $field->getDataType(), $isExact);
             $query2 = $this->search->getFulltextSearchSql('search_text', $value, _CHARSET);
-            if ($query2 != '') {
+            if ('' != $query2) {
                 $tableData[] = '('.$query1.' OR '.$query2.')';
             } else {
                 $tableData[] = $query1;

--- a/xoops_trust_path/modules/xoonips/include/condefs.inc.php
+++ b/xoops_trust_path/modules/xoonips/include/condefs.inc.php
@@ -29,3 +29,7 @@ define('XOONIPS_BLOCK_RANKING_ORDER', '0,1');
 define('XOONIPS_BLOCK_RANKING_VISIBLE', '1,1');
 define('XOONIPS_BLOCK_RANKING_DAYS_ENABLED', 'on');
 define('XOONIPS_BLOCK_RANKING_DAYS', '14');
+
+// xoonips 3.4 compatible list.php
+define('XOONIPS_ITEM_LIST', 'list.php');
+define('XOONIPS_ITEM_LIST_COMPATIBLE', 'listitem.php');

--- a/xoops_trust_path/modules/xoonips/include/search.inc.php
+++ b/xoops_trust_path/modules/xoonips/include/search.inc.php
@@ -21,7 +21,7 @@ function xoonips_search($keywords, $andor, $limit, $offset, $userid)
     if (is_array($keywords)) {
         $pos = 0;
         foreach ($keywords as $val) {
-            if ($pos == 0) {
+            if (0 == $pos) {
                 $keyword .= $val;
             } else {
                 $keyword .= ' '.$andor.' '.$val;
@@ -30,18 +30,18 @@ function xoonips_search($keywords, $andor, $limit, $offset, $userid)
         }
     }
 
-    if (trim($keyword) == '') {
+    if ('' == trim($keyword)) {
         return $ret;
     }
 
     $isExact = false;
-    if ($andor == 'exact') {
+    if ('exact' == $andor) {
         $isExact = true;
     }
     $chandler = Functions::getXoonipsHandler('ItemQuickSearchCondition', $dirname);
     $cobj = &$chandler->get(1);
     $fieldIds = $chandler->getItemFieldIds($cobj);
-    if (count($fieldIds) == 0) {
+    if (0 == count($fieldIds)) {
         return $ret;
     }
     $post_data = array();

--- a/xoops_trust_path/modules/xoonips/language/english/admin.php
+++ b/xoops_trust_path/modules/xoonips/language/english/admin.php
@@ -101,6 +101,10 @@ define($constpref.'_SYSTEM_BASIC_MODERATOR_GROUP_DESC', 'Choose the XOOPS group 
 define($constpref.'_SYSTEM_BASIC_UPLOAD_DIR_TITLE', 'File Upload Directory');
 define($constpref.'_SYSTEM_BASIC_UPLOAD_DIR_DESC', 'Enter absolute path for the file upload direcotry. This direcotry needs write permission for the web server process.');
 define($constpref.'_ERROR_UPLOAD_DIRECTORY', 'The entered file upload directory not exists.');
+define($constpref.'_SYSTEM_BASIC_URL_COMPATIBLE_TITLE', 'XooNIps3 Compatible');
+define($constpref.'_SYSTEM_BASIC_URL_COMPATIBLE_DESC', '');
+define($constpref.'_SYSTEM_BASIC_URL_COMPATIBLE_DEFAULT', 'list.php (default)');
+define($constpref.'_SYSTEM_BASIC_URL_COMPATIBLE_VERSION3', 'listitem.php (version3 compatible)');
 
 // action: SystemMessageSign
 define($constpref.'_SYSTEM_MSGSIGN_SIGN_TITLE', 'Signature Template');

--- a/xoops_trust_path/modules/xoonips/language/ja_utf8/admin.php
+++ b/xoops_trust_path/modules/xoonips/language/ja_utf8/admin.php
@@ -101,6 +101,10 @@ define($constpref.'_SYSTEM_BASIC_MODERATOR_GROUP_DESC', 'XooNIps のモデレー
 define($constpref.'_SYSTEM_BASIC_UPLOAD_DIR_TITLE', 'ファイルアップロードディレクトリ');
 define($constpref.'_SYSTEM_BASIC_UPLOAD_DIR_DESC', '各アイテムの添付ファイルを格納するディレクトリをシステムの絶対パスで指定します。このディレクトリは Web サーバプロセスの権限で書き込みができる必要があります。');
 define($constpref.'_ERROR_UPLOAD_DIRECTORY', '指定されたファイルアップロードディレクトリにアクセス権限がありません');
+define($constpref.'_SYSTEM_BASIC_URL_COMPATIBLE_TITLE', 'XooNIps3互換');
+define($constpref.'_SYSTEM_BASIC_URL_COMPATIBLE_DESC', '');
+define($constpref.'_SYSTEM_BASIC_URL_COMPATIBLE_DEFAULT', 'list.php (デフォルト)');
+define($constpref.'_SYSTEM_BASIC_URL_COMPATIBLE_VERSION3', 'listitem.php (バージョン3互換)');
 
 // action: SystemMessageSign
 define($constpref.'_SYSTEM_MSGSIGN_SIGN_TITLE', '署名テンプレート');

--- a/xoops_trust_path/modules/xoonips/lib/Xoonips/Core/Functions.php
+++ b/xoops_trust_path/modules/xoonips/lib/Xoonips/Core/Functions.php
@@ -65,4 +65,23 @@ class Functions
 
         return $cHandler->setConfig($name, $value);
     }
+
+    /**
+     * get item list url.
+     *
+     * @param string $dirname
+     *
+     * @return string
+     **/
+    public static function getItemListUrl($dirname)
+    {
+        $url = null;
+        if ('on' == self::getXoonipsConfig($dirname, 'url_compatible')) {
+            $url = XOONIPS_ITEM_LIST_COMPATIBLE;
+        } elseif ('off' == self::getXoonipsConfig($dirname, 'url_compatible')) {
+            $url = XOONIPS_ITEM_LIST;
+        }
+
+        return $url;
+    }
 }

--- a/xoops_trust_path/modules/xoonips/lib/Xoonips/Handler/RankingDownloadedItemObjectHandler.php
+++ b/xoops_trust_path/modules/xoonips/lib/Xoonips/Handler/RankingDownloadedItemObjectHandler.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Xoonips\Handler;
+
+use Xoonips\Core\Functions;
+
+/**
+ * ranking downloaded item object handler.
+ */
+class RankingDownloadedItemObjectHandler extends AbstractObjectHandler
+{
+    /**
+     * event type id.
+     */
+    const ETID_DOWNLOAD_FILE = 8;
+
+    /**
+     * constructor.
+     *
+     * @param \XoopsDatabase $db
+     * @param string         $dirname
+     */
+    public function __construct(\XoopsDatabase $db, $dirname)
+    {
+        parent::__construct($db, $dirname);
+        $this->mTable = $db->prefix($dirname.'_ranking_downloaded_item');
+        $this->mPrimaryKey = 'item_id';
+    }
+
+    /**
+     * update downloaded rankings.
+     *
+     * @param int term
+     *
+     * @return bool
+     */
+    public function update($term)
+    {
+        // delete old data
+        if (!$this->deleteAll(null, true)) {
+            return false;
+        }
+        // update downloaded ranking
+        return $this->_recalc($term);
+    }
+
+    /**
+     * recalc.
+     *
+     * @param int term
+     *
+     * @return bool
+     */
+    private function _recalc($term)
+    {
+        $eventLogHandler = Functions::getXoonipsHandler('EventLogObject', $this->mDirname);
+        $fieldlist = 'item_id, COUNT(*) as count';
+        $criteria = new \CriteriaCompo();
+        $criteria->add(new \Criteria('event_type_id', self::ETID_DOWNLOAD_FILE));
+        $criteria->add(new \Criteria('timestamp', $term, '>='));
+        $criteria->setGroupby('item_id');
+        $criteria->setSort('count', 'DESC');
+        if (!$res = $eventLogHandler->open($criteria, $fieldlist)) {
+            return false;
+        }
+        while ($obj = $eventLogHandler->getNext($res)) {
+            $item_id = $obj->get('item_id');
+            $count = $obj->getExtra('count');
+            $ranking = $this->create();
+            $ranking->set('item_id', $item_id);
+            $ranking->set('count', $count);
+            $this->insert($ranking, true);
+        }
+        $eventLogHandler->close($res);
+
+        return true;
+    }
+}

--- a/xoops_trust_path/modules/xoonips/lib/Xoonips/Handler/RankingViewedItemObjectHandler.php
+++ b/xoops_trust_path/modules/xoonips/lib/Xoonips/Handler/RankingViewedItemObjectHandler.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Xoonips\Handler;
+
+use Xoonips\Core\Functions;
+
+/**
+ * ranking viewed item object handler.
+ */
+class RankingViewedItemObjectHandler extends AbstractObjectHandler
+{
+    /**
+     * event type id.
+     */
+    const ETID_VIEW_ITEM = 7;
+
+    /**
+     * constructor.
+     *
+     * @param \XoopsDatabase $db
+     * @param string         $dirname
+     */
+    public function __construct(\XoopsDatabase $db, $dirname)
+    {
+        parent::__construct($db, $dirname);
+        $this->mTable = $db->prefix($dirname.'_ranking_viewed_item');
+        $this->mPrimaryKey = 'item_id';
+    }
+
+    /**
+     * update viewed rankings.
+     *
+     * @param int term
+     *
+     * @return bool
+     */
+    public function update($term)
+    {
+        // delete old data
+        if (!$this->deleteAll(null, true)) {
+            return false;
+        }
+        // update viewed ranking
+        return $this->_recalc($term);
+    }
+
+    /**
+     * recalc.
+     *
+     * @param int term
+     *
+     * @return bool
+     */
+    private function _recalc($term)
+    {
+        $eventLogHandler = Functions::getXoonipsHandler('EventLogObject', $this->mDirname);
+        $fieldlist = 'item_id, COUNT(*) AS count';
+        $criteria = new \CriteriaCompo();
+        $criteria->add(new \Criteria('event_type_id', self::ETID_VIEW_ITEM));
+        $criteria->add(new \Criteria('timestamp', $term, '>='));
+        $criteria->setGroupby('item_id');
+        $criteria->setSort('count', 'DESC');
+        if (!$res = $eventLogHandler->open($criteria, $fieldlist)) {
+            return false;
+        }
+        while ($obj = $eventLogHandler->getNext($res)) {
+            $item_id = $obj->get('item_id');
+            $count = $obj->getExtra('count');
+            $ranking = $this->create();
+            $ranking->set('item_id', $item_id);
+            $ranking->set('count', $count);
+            $this->insert($ranking, true);
+        }
+        $eventLogHandler->close($res);
+
+        return true;
+    }
+}

--- a/xoops_trust_path/modules/xoonips/lib/Xoonips/Object/AbstractObject.php
+++ b/xoops_trust_path/modules/xoonips/lib/Xoonips/Object/AbstractObject.php
@@ -236,15 +236,16 @@ abstract class AbstractObject
             $this->mValues[$key] = $value ? 1 : 0;
             break;
         case XOBJ_DTYPE_INT:
-            $this->mValues[$key] = $value !== null ? intval($value) : null;
+            $this->mValues[$key] = null !== $value ? intval($value) : null;
             break;
         case XOBJ_DTYPE_FLOAT:
-            $this->mValues[$key] = $value !== null ? floatval($value) : null;
+            $this->mValues[$key] = null !== $value ? floatval($value) : null;
             break;
         case XOBJ_DTYPE_STRING:
             if ($this->mTableInfo[$key]['maxlength'] !== null && mb_strlen($value) > $this->mTableInfo[$key]['maxlength']) {
                 return false;
             }
+            // no break
         case XOBJ_DTYPE_TEXT:
             $this->mValues[$key] = $myts->censorString($value);
             break;

--- a/xoops_trust_path/modules/xoonips/lib/Xoonips/Object/RankingDownloadedItemObject.php
+++ b/xoops_trust_path/modules/xoonips/lib/Xoonips/Object/RankingDownloadedItemObject.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Xoonips\Object;
+
+/**
+ * config object.
+ */
+class RankingDownloadedItemObject extends AbstractObject
+{
+    /**
+     * constructor.
+     *
+     * @param string $dirname
+     */
+    public function __construct($dirname)
+    {
+        parent::__construct($dirname);
+        $this->initVar('item_id', XOBJ_DTYPE_INT, null, true);
+        $this->initVar('count', XOBJ_DTYPE_INT, null, true);
+    }
+}

--- a/xoops_trust_path/modules/xoonips/lib/Xoonips/Object/RankingViewedItemObject.php
+++ b/xoops_trust_path/modules/xoonips/lib/Xoonips/Object/RankingViewedItemObject.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Xoonips\Object;
+
+/**
+ * config object.
+ */
+class RankingViewedItemObject extends AbstractObject
+{
+    /**
+     * constructor.
+     *
+     * @param string $dirname
+     */
+    public function __construct($dirname)
+    {
+        parent::__construct($dirname);
+        $this->initVar('item_id', XOBJ_DTYPE_INT, null, true);
+        $this->initVar('count', XOBJ_DTYPE_INT, null, true);
+    }
+}

--- a/xoops_trust_path/modules/xoonips/sql/mysql.sql
+++ b/xoops_trust_path/modules/xoonips/sql/mysql.sql
@@ -679,3 +679,27 @@ CREATE TABLE `{prefix}_{dirname}_item_import_link` (
   PRIMARY KEY (`item_import_log_id`, `item_id`)
 ) ENGINE=InnoDB;
 
+# --------------------------------------------------------
+
+#
+# Table structure for table `{prefix}_{dirname}_ranking_viewed_item`
+#
+
+CREATE TABLE `{prefix}_{dirname}_ranking_viewed_item` (
+  `item_id` int(10) unsigned NOT NULL default '0',
+  `count` int(10) unsigned NOT NULL default '0',
+  PRIMARY KEY  (`item_id`)
+) ENGINE=InnoDB;
+
+# --------------------------------------------------------
+
+#
+# Table structure for table `{prefix}_{dirname}_ranking_downloaded_item`
+#
+
+CREATE TABLE `{prefix}_{dirname}_ranking_downloaded_item` (
+  `item_id` int(10) unsigned NOT NULL default '0',
+  `count` int(10) unsigned NOT NULL default '0',
+  PRIMARY KEY  (`item_id`)
+) ENGINE=InnoDB;
+

--- a/xoops_trust_path/modules/xoonips/templates/blocks/block_tree.html
+++ b/xoops_trust_path/modules/xoonips/templates/blocks/block_tree.html
@@ -68,7 +68,7 @@ var getIndexesInfo = function() {
                             jQuery("[id^=" + idNamePrefix + "]").bind("changed.jstree", function (e, data) {
                                 checked = jQuery(this).jstree("get_selected", true);
                                 jQuery.each(checked, function() {
-                                    url = '<{$smarty.const.XOOPS_URL}>/modules/' + json.dirname + '/list.php?index_id=' + this.id;
+                                    url = '<{$smarty.const.XOOPS_URL}>/modules/' + json.dirname + '/<{$block.itemListUrl}>?index_id=' + this.id;
                                     location.href = url;
                                 });
                             });

--- a/xoops_trust_path/modules/xoonips/templates/export_select.html
+++ b/xoops_trust_path/modules/xoonips/templates/export_select.html
@@ -3,7 +3,7 @@
 <p style="color:blue">&nbsp;&nbsp;&nbsp;<{$smarty.const._MD_XOONIPS_ITEM_EXPORT_SELECT_DESC}></p>
 <div style="text-align:right; margin-left: 10px; margin-bottom: 10px;">
 </div>
-<form action="list.php" method="post">
+<form action="<{$itemListUrl}>" method="post">
 <input type="hidden" name="index_id" value="<{$index_id}>" />
 <input type="hidden" name="op" value="export" />
 <table width="100%" cellspacing="0" class="outer">
@@ -25,7 +25,7 @@
 <div style="text-align:right; margin-left: 10px; margin-bottom: 10px;">
 </div>
 <div style="text-align: left">
- 	<input class="formButton" type="button" value="<{$smarty.const._MD_XOONIPS_LABEL_GO}>" onclick="form.action='list.php'; op.value='export'; submit();" />
+ 	<input class="formButton" type="button" value="<{$smarty.const._MD_XOONIPS_LABEL_GO}>" onclick="form.action='<{$itemListUrl}>'; op.value='export'; submit();" />
 </div>
 </form>
 <{include file="db:`$dirname`_footer.html"}>

--- a/xoops_trust_path/modules/xoonips/templates/index_description.html
+++ b/xoops_trust_path/modules/xoonips/templates/index_description.html
@@ -39,7 +39,7 @@ function back(back) {
 </script>
 <h3><{$smarty.const._MD_XOONIPS_INDEX_DETAILED_DESCRIPTION}></h3>
 <{foreach item=index from=$index_path}>
- / <a href="list.php?index_id=<{$index.index_id}>"><{$index.html_title|xoops_escape}></a>
+ / <a href="<{$itemListUrl}>?index_id=<{$index.index_id}>"><{$index.html_title|xoops_escape}></a>
 <{/foreach}>&nbsp;&nbsp;
 <br />
 <{$errors}>

--- a/xoops_trust_path/modules/xoonips/templates/index_list.html
+++ b/xoops_trust_path/modules/xoonips/templates/index_list.html
@@ -98,7 +98,7 @@ function xoonipsCallback(id, value) {
 </form>
 <table width="100%" border="0" cellspacing="5">
   <tr>
-    <td align="right"><a href="list.php?index_id=<{$xid}>"><{$smarty.const._MD_XOONIPS_ITEM_LISTING_ITEM}></a> | <a href="<{$xoops_url}>/"><{$smarty.const._MD_XOONIPS_LABEL_HOME}></a></td>
+    <td align="right"><a href="<{$itemListUrl}>?index_id=<{$xid}>"><{$smarty.const._MD_XOONIPS_ITEM_LISTING_ITEM}></a> | <a href="<{$xoops_url}>/"><{$smarty.const._MD_XOONIPS_LABEL_HOME}></a></td>
   </tr>
 </table>
 <hr />

--- a/xoops_trust_path/modules/xoonips/templates/list.html
+++ b/xoops_trust_path/modules/xoonips/templates/list.html
@@ -24,7 +24,7 @@ function submit_order_dir( str ){
 <input type="hidden" name="index_id" value="<{$index_id}>" />
 <input type="hidden" name="op" value="" />
 <{foreach item=index from=$index_path}>
- / <a href="list.php?index_id=<{$index.index_id}>"><{$index.html_title|xoops_escape}></a>
+ / <a href="<{$itemListUrl}>?index_id=<{$index.index_id}>"><{$index.html_title|xoops_escape}></a>
 <{/foreach}>&nbsp;&nbsp;
 <{$description|xoops_escape}>
 <span class="no_print_span">
@@ -32,9 +32,9 @@ function submit_order_dir( str ){
  <input class="formButton" type="button" name="edit_index" value="<{$smarty.const._MD_XOONIPS_ITEM_EDIT_INDEX_BUTTON_LABEL}>" onclick="submit_edit_index();" />
  <input class="formButton" type="button" name="edit_index" value="<{$smarty.const._MD_XOONIPS_ITEM_INDEX_DESCRIPTION_BUTTON_LABEL}>" onclick="submit_index_description();" />
 <{/if}>
-<input class="formButton" type="button" value="<{$smarty.const._MD_XOONIPS_ITEM_PRINT_FRIENDLY_BUTTON_LABEL}>" onclick="window.open('<{$smarty.const.XOOPS_URL}>/modules/xoonips/list.php?isPrint=print&index_id=<{$index_id}>&page=<{$page}>&orderby=<{$orderby}>&itemcount=<{$itemcount}>&num_of_items=<{$num_of_items}>');" />
+<input class="formButton" type="button" value="<{$smarty.const._MD_XOONIPS_ITEM_PRINT_FRIENDLY_BUTTON_LABEL}>" onclick="window.open('<{$smarty.const.XOOPS_URL}>/modules/xoonips/<{$itemListUrl}>?isPrint=print&index_id=<{$index_id}>&page=<{$page}>&orderby=<{$orderby}>&itemcount=<{$itemcount}>&num_of_items=<{$num_of_items}>');" />
 <{if !empty($export_enabled)}>
- <input class="formButton" type="button" value="<{$smarty.const._MD_XOONIPS_LABEL_EXPORT}>" onclick="form.action='list.php'; op.value='<{if $export_select==1}>exportselect<{else}>export<{/if}>'; submit();" />
+ <input class="formButton" type="button" value="<{$smarty.const._MD_XOONIPS_LABEL_EXPORT}>" onclick="form.action='<{$itemListUrl}>'; op.value='<{if $export_select==1}>exportselect<{else}>export<{/if}>'; submit();" />
 <{/if}>
 </span>
 <br />

--- a/xoops_trust_path/modules/xoonips/templates/list_index_block.html
+++ b/xoops_trust_path/modules/xoonips/templates/list_index_block.html
@@ -1,10 +1,10 @@
 <table>
  <tr>
   <td style="vertical-align:middle; text-align:center; width: 65px;">
-   <a href="<{$xoops_url}>/modules/<{$dirname}>/list.php?index_id=<{$index.index_id}>"><img src="<{$smarty.const.XOOPS_URL}>/modules/<{$dirname}>/image.php/folder.gif" alt="<{$index.title|xoops_escape}>" /></a>
+   <a href="<{$xoops_url}>/modules/<{$dirname}>/<{$itemListUrl}>?index_id=<{$index.index_id}>"><img src="<{$smarty.const.XOOPS_URL}>/modules/<{$dirname}>/image.php/folder.gif" alt="<{$index.title|xoops_escape}>" /></a>
   </td> 
   <td>
-   <a href="<{$xoops_url}>/modules/<{$dirname}>/list.php?index_id=<{$index.index_id}>"><{$index.title|xoops_escape}></a>&nbsp;&nbsp; <{$index.description|xoops_escape}><br />
+   <a href="<{$xoops_url}>/modules/<{$dirname}>/<{$itemListUrl}>?index_id=<{$index.index_id}>"><{$index.title|xoops_escape}></a>&nbsp;&nbsp; <{$index.description|xoops_escape}><br />
    <{$index.child_index_num}> Indexes / <{$index.child_item_num}> Items
   </td>
  </tr>

--- a/xoops_trust_path/modules/xoonips/xoops_version.php
+++ b/xoops_trust_path/modules/xoonips/xoops_version.php
@@ -5,7 +5,7 @@ require_once __DIR__.'/include/common.inc.php';
 Xoonips_Utils::loadModinfoMessage('xoonips');
 
 $modversion['name'] = _MI_XOONIPS_NAME;
-$modversion['version'] = 4.20;
+$modversion['version'] = 4.30;
 $modversion['description'] = _MI_XOONIPS_DESC;
 $modversion['credits'] = 'Neuroinformatics Japan Center, RIKEN BSI (https://nijc.brain.riken.jp/)';
 $modversion['author'] = 'The XooNIps Project (http://xoonips.osdn.jp/)';
@@ -77,6 +77,8 @@ $modversion['tables'] = array(
     '{prefix}_{dirname}_item_field_group_field_detail_link',
     '{prefix}_{dirname}_item_import_log',
     '{prefix}_{dirname}_item_import_link',
+    '{prefix}_{dirname}_ranking_viewed_item',
+    '{prefix}_{dirname}_ranking_downloaded_item',
 );
 
 // Admin things


### PR DESCRIPTION
## Improving compatibility with version 3.4
* add new feature to switch 3.4 compatible item listing page url l"istitem.php".
  * If utilize this feature, the file name of "list.php" (html side) have to rename to "listitem.php".
* use 3.4 compatible procedures for creating ranking data of item view and item download.
* implement updater for applying these changes and update version to 4.30. 